### PR TITLE
[add] Calculate disk usage of fetched model and display the same

### DIFF
--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -1,5 +1,6 @@
 import click
 
+import os
 from . import ersilia_cli
 from .. import echo
 from ...hub.fetch.fetch import ModelFetcher
@@ -25,6 +26,12 @@ def fetch_cmd():
     def fetch(model, mode, dockerize):
         mdl = ModelBase(model)
         model_id = mdl.model_id
+        url = "https://github.com/ersilia-os/{0}".format(model_id)
+        cmd = "echo " + url + "| perl -ne 'print $1 if m!([^/]+/[^/]+?)(?:\.git)?$!' | xargs -I{} curl -s -k https://api.github.com/repos/'{}' | grep size"
+        echo(
+            "The disk storage of this model in KB is"
+        )
+        os.system(cmd) 
         echo(
             ":down_arrow:  Fetching model {0}: {1}".format(model_id, mdl.slug),
             fg="blue",


### PR DESCRIPTION
Solves #7 
Using the very handy GitHub API to get information about the model repo in question, then grepping the API response to simply show the `size` in KB. 
My changes to achieve this are:

```bash
        import os

        url = "https://github.com/ersilia-os/{0}".format(model_id)
        cmd = "echo " + url + "| perl -ne 'print $1 if m!([^/]+/[^/]+?)(?:\.git)?$!' | xargs -I{} curl -s -k https://api.github.com/repos/'{}' | grep size"
        echo(
            "The disk storage of this model in KB is"
        )
        os.system(cmd) 
```

Attached herein is how the output looks currently:
<img width="600" alt="Screenshot 2022-03-28 at 3 30 23 PM" src="https://user-images.githubusercontent.com/55790848/160374810-e634157e-96f3-41f3-8e87-9b7feba5d96a.png">

