### PR TITLE
add streamlit app ersilia-app.py

### DIFF
--- a/app1.py
+++ b/app1.py
@@ -1,0 +1,4 @@
+import streamlit as st
+def app():
+    st.title('')
+    st.write('About')

--- a/app2.py
+++ b/app2.py
@@ -8,6 +8,12 @@ from rdkit.Chem import Draw
 
 import streamlit as st
 
+def show_output(obj):
+    obj = list(obj) 
+    d = dict(obj[0])
+    d = d['output']
+    pair = next(iter((d.items())) )
+    st.write(pair[0], " : ", pair[1])
 
 def app():
     st.header("Ersilia Model Hub")
@@ -19,21 +25,33 @@ def app():
 
     compound_smiles = st.text_input("Enter the chemical structure", "")
     m = Chem.MolFromSmiles(compound_smiles)
-    im=Draw.MolToImage(m)
-
+    im=Draw.MolToImage(m,size=(200,200))
     st.image(im)
 
-    opt = st.radio("Select API", ('Predict','Calculate'))
-    if opt=='Predict':
-        obj = model.predict(compound_smiles)
-        obj = list(obj) 
-        json_response = obj[0]
-        st.write(json_response)
+    apis = tuple(model.get_apis())
+
+    #if only one api available, no need to create radio buttons
+    if len(apis) == 1:
+        opt = apis[0]
+        if opt=='predict':
+            if(st.button("Predict")):
+                output_obj = model.predict(compound_smiles)
+                show_output(output_obj)
+        elif opt=='calculate':
+            if(st.button("Calculate")):
+                output_obj = model.calculate(compound_smiles)
+                show_output(output_obj)
+    # if model supports more than one api, create 
     else:
-        obj = model.calculate(compound_smiles)
-        obj = list(obj) 
-        json_response = obj[0]
-        st.write(json_response)
+        opt = st.radio("Select API", apis)
+        if opt=='predict':
+            output_obj = model.predict(compound_smiles)
+            show_output(output_obj)
+        elif opt=='calculate':
+            output_obj = model.calculate(compound_smiles)
+            show_output(output_obj)
+            
+    
 
 
 

--- a/app2.py
+++ b/app2.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from ersilia import ErsiliaModel
+import json
+
+from rdkit import Chem
+from rdkit.Chem.Draw import IPythonConsole
+from rdkit.Chem import Draw
+
+import streamlit as st
+
+
+def app():
+    st.header("Ersilia Model Hub")
+    st.subheader("Calculate and Predict properties for your molecules of interest")
+
+    option = st.selectbox('Which model would you like to run?',('chemprop-antibiotic','molecular-weight'))
+    model = ErsiliaModel(option)
+    model.serve()
+
+    compound_smiles = st.text_input("Enter the chemical structure", "")
+    m = Chem.MolFromSmiles(compound_smiles)
+    im=Draw.MolToImage(m)
+
+    st.image(im)
+
+    opt = st.radio("Select API", ('Predict','Calculate'))
+    if opt=='Predict':
+        obj = model.predict(compound_smiles)
+        obj = list(obj) 
+        json_response = obj[0]
+        st.write(json_response)
+    else:
+        obj = model.calculate(compound_smiles)
+        obj = list(obj) 
+        json_response = obj[0]
+        st.write(json_response)
+
+
+

--- a/app3.py
+++ b/app3.py
@@ -1,0 +1,4 @@
+import streamlit as st
+def app():
+    st.title('')
+    st.write('About')

--- a/ersilia-app.py
+++ b/ersilia-app.py
@@ -1,0 +1,17 @@
+import app1
+import app2
+import app3
+import streamlit as st
+
+PAGES = {
+    "About" : app1,
+    "API": app2,
+    "Catalog": app3
+}
+st.sidebar.title('Navigation')
+selection = st.sidebar.radio("Go to", list(PAGES.keys()))
+page = PAGES[selection]
+page.app()
+
+
+

--- a/ersilia/app/contrib/app1.py
+++ b/ersilia/app/contrib/app1.py
@@ -1,0 +1,4 @@
+import streamlit as st
+def app():
+    st.title('')
+    st.write('About')

--- a/ersilia/app/contrib/app2.py
+++ b/ersilia/app/contrib/app2.py
@@ -1,0 +1,64 @@
+import streamlit as st
+from ersilia import ErsiliaModel
+import json
+
+from rdkit import Chem
+from rdkit.Chem.Draw import IPythonConsole
+from rdkit.Chem import Draw
+
+import streamlit as st
+from ersilia.hub.content.catalog import ModelCatalog
+
+
+def show_output(obj):
+    obj = list(obj) 
+    d = dict(obj[0])
+    d = d['output']
+    pair = next(iter((d.items())) )
+    st.write(pair[0], " : ", "%.3f"%(float(pair[1])))
+
+mc = ModelCatalog()
+local_catalog = str(mc.local()).split('\n')[2:]
+models_local = tuple([i.split()[1] for i in local_catalog])
+
+def app():
+    st.header("Ersilia Model Hub")
+    st.subheader("Calculate and Predict properties for your molecules of interest")
+
+    option = st.selectbox('Which model would you like to run?',models_local)
+    model = ErsiliaModel(option)
+    model.serve()
+
+    compound_smiles = st.text_input("Enter the chemical structure", "")
+    m = Chem.MolFromSmiles(compound_smiles)
+    im=Draw.MolToImage(m,size=(200,200))
+    st.image(im)
+
+    apis = tuple(model.get_apis())
+
+    #if only one api available, no need to create radio buttons
+    if len(apis) == 1:
+        opt = apis[0]
+        if opt=='predict':
+            if(st.button("Predict")):
+                output_obj = model.predict(compound_smiles)
+                show_output(output_obj)
+        elif opt=='calculate':
+            if(st.button("Calculate")):
+                output_obj = model.calculate(compound_smiles)
+                show_output(output_obj)
+
+    # if model supports more than one api, create radio buttons
+    else:
+        opt = st.radio("Select API", apis)
+        if opt=='predict':
+            output_obj = model.predict(compound_smiles)
+            show_output(output_obj)
+        elif opt=='calculate':
+            output_obj = model.calculate(compound_smiles)
+            show_output(output_obj)
+            
+    
+
+
+

--- a/ersilia/app/contrib/app3.py
+++ b/ersilia/app/contrib/app3.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+def app():
+    st.title('Catalog')
+    st.header('Local')
+  
+    st.header('Ersilia Hub')
+ 

--- a/ersilia/app/contrib/ersilia-app.py
+++ b/ersilia/app/contrib/ersilia-app.py
@@ -1,0 +1,17 @@
+import app1
+import app2
+import app3
+import streamlit as st
+
+PAGES = {
+    "About" : app1,
+    "API": app2,
+    "Catalog": app3
+}
+st.sidebar.title('Navigation')
+selection = st.sidebar.radio("Go to", list(PAGES.keys()))
+page = PAGES[selection]
+page.app()
+
+
+


### PR DESCRIPTION
I have created a simple streamlit app as suggested in issue #126
It has multi-page view that could be used to extend its functionality. 
Right now user can choose a model and perform predict and calculate operations on the given input string and display the output.
It also shows the representation of the molecular structure of the input using the rdkit python library as suggested by @GemmaTuron 
I would love to hear your feedback and work on your suggestions. 

![image](https://user-images.githubusercontent.com/98670206/162085044-feb84669-439f-4002-809a-09f108fc8775.png)


