### PR TITLE
[bfix] print the command output correctly to show the size in the CLI

### DIFF
--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -26,12 +26,14 @@ def fetch_cmd():
     def fetch(model, mode, dockerize):
         mdl = ModelBase(model)
         model_id = mdl.model_id
-        url = "https://github.com/ersilia-os/{0}".format(model_id)
+        url = "https://github.com/ersilia-os/{0}.git/info/lfs".format(model_id)
         cmd = "echo " + url + "| perl -ne 'print $1 if m!([^/]+/[^/]+?)(?:\.git)?$!' | xargs -I{} curl -s -k https://api.github.com/repos/'{}' | grep size"
         echo(
             "The disk storage of this model in KB is"
         )
-        os.system(cmd) 
+        print (
+            os.system(cmd) 
+        )
         echo(
             ":down_arrow:  Fetching model {0}: {1}".format(model_id, mdl.slug),
             fg="blue",


### PR DESCRIPTION
Currently the cmd output of 
```
url = "https://github.com/ersilia-os/{0}.git/info/lfs".format(model_id)
        cmd = "echo " + url + "| perl -ne 'print $1 if m!([^/]+/[^/]+?)(?:\.git)?$!' | xargs -I{} curl -s -k https://api.github.com/repos/'{}' | grep size"
echo(
     "The disk storage of this model in KB is"
        )
os.system(cmd) 
```
wasn't showing up in the terminal.

Debugged and fixed the above by:
```
        print (
            os.system(cmd) 
        )
```