### PR TITLE
Dependabot configured to create more PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Configure dependabot to create 10 PRs. By default it creates only 5 PRs. We can increase this even more in the future.

Increasing the PR creation config in dependabot.yml file based on the error: https://github.com/ersilia-os/ersilia/network/updates/480983059
<img width="901" alt="image" src="https://user-images.githubusercontent.com/5500812/195207402-53ca6c29-b8a9-42f6-8f28-939b25e2b1a6.png">
