### PR TITLE
Update the scheduled model prediction runs to run multiple 

### DIFF
--- a/.github/workflows/predict-model.yml
+++ b/.github/workflows/predict-model.yml
@@ -5,6 +5,9 @@ on:
   
 jobs:
   build:
+    strategy:
+      matrix:
+        count: [0, 1, 2, 3, 4]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3


### PR DESCRIPTION
## Description

Adds a matrix to kick off multiple model prediction jobs. The count field doesn't do anything, it's just there to create multiple runs. If anyone knows a better approach, please let me know! 

## Testing
kicked off an action run on this branch: https://github.com/ersilia-os/ersilia/actions/workflows/predict-model.yml