### PR TITLE
Fix _version object doesn't exist on windows

### DIFF
--- a/ersilia/__init__.py
+++ b/ersilia/__init__.py
@@ -1,7 +1,10 @@
 # Version
 from ._version import __version__
 
-del _version
+try:
+    del _version
+except:
+    pass
 
 # External imports
 import os


### PR DESCRIPTION
Fix _version object doesn't exist on windows