### PR TITLE
Adding a dockerfile and an easy-install script.

### DIFF
--- a/dockerfiles/easyinstallimage/Dockerfile
+++ b/dockerfiles/easyinstallimage/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04 
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update
+RUN apt-get install -y tzdata
+RUN apt-get install -y build-essential wget git curl zip docker
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-x86_64.sh
+RUN chmod +x Miniconda3-py37_4.11.0-Linux-x86_64.sh
+RUN bash Miniconda3-py37_4.11.0-Linux-x86_64.sh -b
+RUN eval "$(/root/miniconda3/bin/conda shell.bash hook)" &&\
+conda create -y -n ersilia python=3.7 &&\
+conda activate 
+ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
+RUN git clone https://github.com/ersilia-os/ersilia.git
+RUN eval "$(/root/miniconda3/bin/conda shell.bash hook)" &&\
+conda activate ersilia &&\
+python -m pip install -e ersilia/.
+ENV PATH "$PATH:$PATH:/root/miniconda3/envs/ersilia/bin"
+RUN mv /root/miniconda3/envs/ersilia/bin/ersilia /root/miniconda3/envs/ersilia/bin/ersilia_exec
+COPY ./required_files/ersilia /root/miniconda3/envs/ersilia/bin/
+RUN chmod +x /root/miniconda3/envs/ersilia/bin/ersilia
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/dockerfiles/easyinstallimage/dockerersilia.sh
+++ b/dockerfiles/easyinstallimage/dockerersilia.sh
@@ -1,0 +1,50 @@
+#Check if the ~/ersiliafiles exists. If not, create one.
+echo "Welcome to ersilia docker image quickstart!"
+echo "This script will fetch and run ersilia docker image."
+echo "It will also create a directory called \"ersiliafiels\" in your home directory."
+echo "This is the location where ersilia stores all the data."
+#read -p "Do you wish to continue?"
+#if [[ ! $REPLY =~ ^[Yy]$ ]]
+#then
+#        exit
+#fi
+
+cd ~ || exit
+if [ ! -d $(pwd)/ersiliafiles ]
+then
+        echo "Directory ~/ersiliafiles doesn't exist. Creating it now."
+        mkdir $(pwd)/ersiliafiles
+fi
+#Docker startup
+if ! docker ps|grep -q "ersilia"
+then
+        sudo docker run --name ersilia -d --mount type=bind,source=$(pwd)/ersiliafiles,target=/root/eos ersiliaos/ersilia
+else
+        echo "Ersilia docker container already started"
+fi
+#Shell detection
+if echo $SHELL|grep -q "zsh"; then
+        rcfile=~/.zshrc
+elif echo $SHELL|grep -q "bash"; then
+        rcfile=~/.bashrc
+elif ps -p $$|grep -q "sh"; then
+        rcfile=~/.shrc
+else    echo "Shell unknown. Please add the ersilia alias manually to your rc file."
+        echo "alias ersilia="docker exec -it ersilia /bin/bash""
+fi
+echo  "Your rc file has been found at "$rcfile
+#Add ersilia alias
+if grep -q "alias ersilia" $rcfile; then
+        echo "alias to ersilia already exists in " $rcfile
+else
+echo "alias ersilia=\"docker exec -it ersilia /bin/bash\"" >> $rcfile
+echo "Alias added to ersilia"
+alias ersilia="docker exec -it ersilia /bin/bash"
+fi
+if docker ps|grep -q ersilia; then
+        echo "Ersilia is up and running!"
+        docker ps|grep "ersilia"
+        echo "To start using ersilia just type 'ersilia' in your shell."
+else
+        echo "Something went wrong!"
+fi

--- a/dockerfiles/easyinstallimage/required_files/ersilia
+++ b/dockerfiles/easyinstallimage/required_files/ersilia
@@ -1,0 +1,3 @@
+#!/bin/bash
+eval "$(/root/miniconda3/bin/conda shell.bash hook)"
+/root/miniconda3/envs/ersilia/bin/ersilia_exec "$@"


### PR DESCRIPTION
Added an easyinstall script in dockerfiles/easyinstallimage
This script is meant for the automation of running ersilia in docker.
It also creates an alias to ersilia in the host system.
How to use:
1. Run script dockerersilia.sh
2 The script will:
- Create a directory in ~/ersiliafiles of the host system. The directory is mounted in the Docker image in /root/eos directory.
- Try to fetch Ersilia docker image and start it.
- Add an alias to the shell rc file: alias ersilia="docker exec -it ersilia /bin/bash" - so everytime you type ersilia in the host system shell it will enter Ersilia docekr container.
 