### PR TITLE
Add function that returns the python path of the conda enviroment.

### DIFF
--- a/ersilia/utils/conda.py
+++ b/ersilia/utils/conda.py
@@ -3,6 +3,7 @@ import os
 import json
 import hashlib
 import shutil
+import subprocess
 from collections import defaultdict, OrderedDict
 from .terminal import run_command, run_command_check_output
 from .docker import SimpleDockerfileParser
@@ -273,6 +274,16 @@ class SimpleConda(CondaUtils):
             if l.startswith(environment):
                 envs_list += [l.split(" ")[0]]
         return envs_list
+
+    def get_python_path_env(self, environment):
+        if not self.exists(environment):
+            raise Exception(
+                "{0} environment does not exist".format(environment))
+        python_path = subprocess.check_output(
+            "which python", shell=True).strip()
+        index_env = python_path.decode('utf-8').find("envs/") + 5
+        python_path_to_envs = python_path.decode('utf-8')[0:index_env]
+        return "{0}{1}/bin/python".format(python_path_to_envs, environment)
 
     def delete_one(self, environment):
         if not self.exists(environment):


### PR DESCRIPTION
It is intended to incorporate as a utility a function that allows obtaining the python path of a conda environment for future cases in which it is necessary to know this variable from the python interpreter.