### PR TITLE
Fix typos in logging statements

### DIFF
--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -88,7 +88,7 @@ class ErsiliaModel(ErsiliaBase):
         if not self._is_available_locally and fetch_if_not_available:
             self.logger.info("Model is not available locally")
             do_fetch = yes_no_input(
-                "Requested model {0} if not available locally. Do you want to fetch it? [Y/n]".format(
+                "Requested model {0} is not available locally. Do you want to fetch it? [Y/n]".format(
                     self.model_id
                 ),
                 default_answer="Y",

--- a/ersilia/utils/exceptions_utils/throw_ersilia_exception.py
+++ b/ersilia/utils/exceptions_utils/throw_ersilia_exception.py
@@ -32,7 +32,7 @@ def throw_ersilia_exception(func):
             text += "Or feel free to reach out to us at:\n"
             text += " - hello[at]ersilia.io\n\n"
             text += "If you haven't, try to run your command in verbose mode (-v in the CLI)\n"
-            text += " - You fill find the console log file in: {0}/{1}".format(
+            text += " - You will find the console log file in: {0}/{1}".format(
                 EOS, CURRENT_LOGGING_FILE
             )
             echo(text, fg="green")


### PR DESCRIPTION
Fixed two typos in the logging statements. Replaced "if" with "is" in [model.py](https://github.com/ersilia-os/ersilia/blob/master/ersilia/core/model.py) and replaced "fill" with "will" in [throw_ersilia_exception.py](https://github.com/ersilia-os/ersilia/blob/master/ersilia/utils/exceptions_utils/throw_ersilia_exception.py).