### PR TITLE
Add support for GitHub Actions Version Update.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Add Dependabot version update config in the dependabot.yml file to support the GitHub actions version update. 