### PR TITLE
Set Python3.10 for workflows that install ersilia

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Add conda to system path
         run: echo $CONDA/bin >> $GITHUB_PATH
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+      
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 

--- a/.github/workflows/predict-model-input.yml
+++ b/.github/workflows/predict-model-input.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10
+
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/predict-model.yml
+++ b/.github/workflows/predict-model.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10
+
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/quick-manual-model-test.yml
+++ b/.github/workflows/quick-manual-model-test.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10
+
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/test-colab.yml
+++ b/.github/workflows/test-colab.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+
       - name: Install dependencies
         run: |
           source activate


### PR DESCRIPTION
Hi @miquelduranfrigola,
For workflows that install ersilia, python for conda has been set to 3.10.10, and six files have been modified.
The actions that were failing;
- Deploy and test ersilia on PR: `.github/workflows/pr_check.yml`
- Install Ersilia: `.github/workflows/install.yml`
- Test Colab Notebook: `.github/workflows/test-colab.yml`

The following were not failing as they are run manually;
-  Ersilia model output prediction (Manual):  `.github/workflows/predict-model.yml`
- Ersilia model output prediction(runs every two hours but schedule is turned off):  `.github/workflows/predict-model.yml`
- Quick model test (Manual):  `.github/workflows/quick-manual-model-test.yml`