### PR TITLE
Migrate setup to poetry

### DIFF
--- a/.github/scripts/static_version_writer.py
+++ b/.github/scripts/static_version_writer.py
@@ -1,16 +1,29 @@
 import os
-import os
+import re
 from importlib.util import module_from_spec, spec_from_file_location
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
+def version_writer(func):
+    def wrapper(package_path):
+        version = func(package_path)
+        toml_path = os.path.join(package_path, "..", "pyproject.toml")
+        with open(toml_path, "r") as f:
+            toml_content = f.read()
+        toml_content = re.sub("version\s=\s\"[0-9\.]+\"", f"version = \"{version}\"", toml_content)
+        with open(toml_path, "w") as f:
+            f.write(toml_content)
+        return version
+    return wrapper
 
+@version_writer
 def get_version(package_path):
     spec = spec_from_file_location("version", os.path.join(package_path, "_version.py"))
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
     version = module.get_version_for_setup()
     return version
+
 
 
 try:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,10 +28,14 @@ jobs:
           wget https://raw.githubusercontent.com/ersilia-os/ersilia/master/ersilia/_static_version.py
           mv _static_version.py ersilia/.
 
-      - name: Install dependencies
+      - name: Install Poetry
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+            python -m pip install --upgrade pip
+            pip install setuptools wheel twine
+            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+            source $HOME/.poetry/env
+            echo `poetry --version`
+            echo "Poetry successfully installed"
 
       - name: Build and publish
         env:
@@ -39,6 +43,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
         run: |
-          # python setup.py sdist bdist_wheel
+          source $HOME/.poetry/env
           poetry build
           twine upload --verbose --skip-existing dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,5 +39,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
         run: |
-          python setup.py sdist bdist_wheel
+          # python setup.py sdist bdist_wheel
+          poetry build
           twine upload --verbose --skip-existing dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/ersilia/setup/requirements/__init__.py
+++ b/ersilia/setup/requirements/__init__.py
@@ -1,0 +1,8 @@
+from .bentoml import BentoMLRequirement
+
+def check_bentoml():
+    req = BentoMLRequirement()
+    if not req.is_bentoml_ersilia_version():
+        req.install()
+    return
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ docs = ["sphinx", "jinja2"]
 test = ["pytest", "fuzzywuzzy"]
 #all = [lake, docs, test]
 
+[tool.poetry.scripts]
+ersilia = "ersilia.cli:cli"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = ["pytest", "fuzzywuzzy"]
 
 [tool.poetry.scripts]
 ersilia = "ersilia.cli:cli"
-bentoml = "ersilia.setup.requirements.bentoml:install"
+bentoml = "ersilia.setup.requirements:check_bentoml"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,14 @@ pytest = {version = "^7.4.0", optional = true}
 fuzzywuzzy = {version = "^0.18.0", optional = true}
 sphinx = {version = ">=5.3.0", optional = true} # For compatibility with python 3.7.x
 jinja2 = {version = "^3.1.2", optional = true}
+levenshtein = {version = "^0.21.1", optional = true} # For faster fuzzy search
 
 
 [tool.poetry.extras]
 # Instead of using poetry dependency groups, we use extras to make it pip installable
 lake = ["isaura"]
 docs = ["sphinx", "jinja2"]
-test = ["pytest", "fuzzywuzzy"]
+test = ["pytest", "fuzzywuzzy", "levenshtein"]
 #all = [lake, docs, test]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,10 @@ classifiers=[
 packages = [
     {include = "ersilia"},
 ]
-include = [
+includ = [
     "ersilia/hub/content/metadata/*.txt",
-    "ersilia/io/types/examples/*.tsv,
+    "ersilia/io/types/examples/*.tsv",
 ]
-
 
 [tool.poetry.dependencies]
 python = ">=3.7"
@@ -35,20 +34,19 @@ validators = [
     {version="0.20.0", python="3.7.*"},
     {version="~0.21.0", python=">=3.8"},
 ]
-h5py = [
-    {version="~3.7.0", python=">=3.7", markers="extra=='lake'"},
-    {version="~3.9.0", python=">=3.7"}
-]
-loguru = [
-    {version="^0.6.0", python=">=3.7", markers="extra=='lake'"},
-    {version="~0.7.0", python=">=3.7"}
-]
+h5py = "^3.7.0" # For compatibility with isaura
+loguru = "^0.6.0" # For compatibility with isaura
 pyairtable = "<2"
 PyYAML = "^6.0.1"
 dockerfile-parse = "^2.0.1"
 tqdm = "^4.66.1"
 click = "^8.1.7"
 docker = "^6.1.3"
+isaura = {version="0.1", optional=true}
+pytest = {version = "^7.4.0", optional = true}
+fuzzywuzzy = {version = "^0.18.0", optional = true}
+sphinx = {version = ">=5.3.0", optional = true} # For compatibility with python 3.7.x
+jinja2 = {version = "^3.1.2", optional = true}
 
 
 [tool.poetry.extras]
@@ -56,6 +54,8 @@ docker = "^6.1.3"
 lake = ["isaura"]
 docs = ["sphinx", "jinja2"]
 test = ["pytest", "fuzzywuzzy"]
+#all = [lake, docs, test]
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = ["pytest", "fuzzywuzzy"]
 
 [tool.poetry.scripts]
 ersilia = "ersilia.cli:cli"
-bentoml_requirement = "ersilia.setup.requirements.bentoml:install"
+bentoml = "ersilia.setup.requirements.bentoml:install"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ersilia"
-version = "0.1.24"
+version = "0.1.27"
 description = "A hub of AI/ML models for open source drug discovery and global health"
 license = "GPLv3"
 authors = ["Ersilia Open Source Initiative <hello@ersilia.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ersilia"
-version = "0.1.22"
+version = "0.1.24"
 description = "A hub of AI/ML models for open source drug discovery and global health"
 license = "GPLv3"
 authors = ["Ersilia Open Source Initiative <hello@ersilia.io>"]
@@ -21,7 +21,7 @@ classifiers=[
 packages = [
     {include = "ersilia"},
 ]
-includ = [
+include = [
     "ersilia/hub/content/metadata/*.txt",
     "ersilia/io/types/examples/*.tsv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,62 @@
+[tool.poetry]
+name = "ersilia"
+version = "0.1.22"
+description = "A hub of AI/ML models for open source drug discovery and global health"
+license = "GPLv3"
+authors = ["Ersilia Open Source Initiative <hello@ersilia.io>"]
+readme = "README.md"
+homepage = "https://ersilia.io"
+repository = "https://github.com/ersilia-os/ersilia"
+documentation = "https://ersilia.io/model-hub"
+keywords= ["drug-discovery", "machine-learning", "ersilia", "open-science", "global-health", "model-hub", "infectious-diseases"]
+classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+packages = [
+    {include = "ersilia"},
+]
+include = [
+    "ersilia/hub/content/metadata/*.txt",
+    "ersilia/io/types/examples/*.tsv,
+]
+
+
+[tool.poetry.dependencies]
+python = ">=3.7"
+inputimeout = "^1.0.4"
+emoji = "^2.8.0"
+validators = [
+    {version="0.20.0", python="3.7.*"},
+    {version="~0.21.0", python=">=3.8"},
+]
+h5py = [
+    {version="~3.7.0", python=">=3.7", markers="extra=='lake'"},
+    {version="~3.9.0", python=">=3.7"}
+]
+loguru = [
+    {version="^0.6.0", python=">=3.7", markers="extra=='lake'"},
+    {version="~0.7.0", python=">=3.7"}
+]
+pyairtable = "<2"
+PyYAML = "^6.0.1"
+dockerfile-parse = "^2.0.1"
+tqdm = "^4.66.1"
+click = "^8.1.7"
+docker = "^6.1.3"
+
+
+[tool.poetry.extras]
+# Instead of using poetry dependency groups, we use extras to make it pip installable
+lake = ["isaura"]
+docs = ["sphinx", "jinja2"]
+test = ["pytest", "fuzzywuzzy"]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = ["pytest", "fuzzywuzzy"]
 
 [tool.poetry.scripts]
 ersilia = "ersilia.cli:cli"
+bentoml_requirement = "ersilia.setup.requirements.bentoml:install"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- [x] Added `pyproject.toml` to mimic setup in setup.py
- [x] Updated tag to version workflow to auto update version in pyproject.toml
- [x] Updated python publish workflow to build with poetry instead of setup.py. By default poetry builds both source and binary distributions (I think I need to update the python image used in this workflow to actually contain poetry :sweat_smile: )