### PR TITLE
add a comment for the user on failure

### DIFF
--- a/.github/templates/approve-workflow-failed.md
+++ b/.github/templates/approve-workflow-failed.md
@@ -1,0 +1,7 @@
+### Workflow Failure ❌
+
+@{{ issue_creator }} the `/approve` workflow has failed. View the logs here for more information:
+
+🔗 [Workflow logs]({{ workflow_url }})
+
+You may need to delete the following repo that was created via this workflow run since the run was not fully successful: [ersilia-os/{{ repo_name }}](https://github.com/ersilia-os/{{ repo_name }})

--- a/.github/templates/approve-workflow-failed.md
+++ b/.github/templates/approve-workflow-failed.md
@@ -1,6 +1,6 @@
 ### Workflow Failure ❌
 
-@{{ issue_creator }} the `/approve` workflow has failed. View the logs here for more information:
+@{{ issue_creator }} (or other maintainers) the `/approve` workflow has failed. View the logs here for more information:
 
 🔗 [Workflow logs]({{ workflow_url }})
 

--- a/.github/workflows/approve-dispatch.yml
+++ b/.github/workflows/approve-dispatch.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v3.5.3
 
+      # construct the url to this workflow run
+      - name: workflow url
+        id: workflow-url
+        run: |
+          echo "workflow_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
       # parse the issue body from free form text to a structured JSON object
       - name: parse issue
         uses: GrantBirki/issue-template-parser@v7.0.0
@@ -161,3 +167,15 @@ jobs:
           vars: |
             repo_name: ${{ steps.create-model-repo.outputs.repo_name }}
             issue_creator: ${{ steps.issue-creator.outputs.issue_creator }}
+
+      # steps to run if the workflow fails for any reason
+      - name: comment on failure
+        if: failure()
+        uses: GrantBirki/comment@7016e89e8f225b0f18f1fbb7fd10263df2772a05 # pin@v2.0.8
+        with:
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          file: .github/templates/approve-workflow-failed.md
+          vars: |
+            repo_name: ${{ steps.create-model-repo.outputs.repo_name }}
+            issue_creator: ${{ steps.issue-creator.outputs.issue_creator }}
+            workflow_url: ${{ steps.workflow-url.outputs.workflow_url }}


### PR DESCRIPTION
This pull request leaves a comment for the user with relevant links if the `/approve` workflow fails. It didn't feel too safe to be deleting repos directly from an automated workflow run so I chose not to run those operations here. Rather, this just lets the user know a failure occurred with direct links to the orphaned repo and the workflow logs.

related: https://github.com/ersilia-os/ersilia/issues/930