### PR TITLE
fix a problem with aws access key

### DIFF
--- a/.github/scripts/convert_airtable_to_json.py
+++ b/.github/scripts/convert_airtable_to_json.py
@@ -17,7 +17,7 @@ def convert_airtable_to_json(airtable_api_key, aws_access_key_id, aws_secret_acc
 
     data=response.json()
     records_models= [record['fields'] for record in data['records']]
-    models_json=json.dumps(records_models)
+    models_json=json.dumps(records_models, indent=4)
 
     #Load JSON in AWS S3 bucket
     s3 = boto3.client('s3',aws_access_key_id=aws_access_key_id,aws_secret_access_key=aws_secret_access_key,region_name=AWS_ACCOUNT_REGION)

--- a/.github/workflows/airtable_to_json.yml
+++ b/.github/workflows/airtable_to_json.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Convert to backend of Airtable to JSON FILE
         env:
             AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           python .github/scripts/convert_airtable_to_json.py $AIRTABLE_API_KEY $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Related to this PR: [Convert Airtable models to a JSON file](https://github.com/ersilia-os/ersilia/pull/1011) In the action this issue was presented: The error "a non-empty Access Key (AKID) must be provided in the credential" and It is fixed by adding the name of the access variable key to S3 correctly.