### PR TITLE
Add support for model input example.csv in the ersilia example command

### DIFF
--- a/ersilia/cli/commands/example.py
+++ b/ersilia/cli/commands/example.py
@@ -29,6 +29,6 @@ def example_cmd():
             model_id = session.current_model_id()
         eg = ExampleGenerator(model_id=model_id)
         if file_name is None:
-            echo(json.dumps(eg.example(n_samples, file_name, simple, predefined), indent=4))
+            echo(json.dumps(eg.example(n_samples, file_name, simple, try_predefined=predefined), indent=4))
         else:
-            eg.example(n_samples, file_name, simple)
+            eg.example(n_samples, file_name, simple, try_predefined=predefined)

--- a/ersilia/cli/commands/example.py
+++ b/ersilia/cli/commands/example.py
@@ -20,7 +20,8 @@ def example_cmd():
     @click.option("--n_samples", "-n", default=5, type=click.INT)
     @click.option("--file_name", "-f", default=None, type=click.STRING)
     @click.option("--simple/--complete", "-s/-c", default=True)
-    def example(model, n_samples, file_name, simple):
+    @click.option("--predefined/--random", "-p/-r", default=False)
+    def example(model, n_samples, file_name, simple, predefined):
         if model is not None:
             model_id = ModelBase(model).model_id
         else:
@@ -28,6 +29,6 @@ def example_cmd():
             model_id = session.current_model_id()
         eg = ExampleGenerator(model_id=model_id)
         if file_name is None:
-            echo(json.dumps(eg.example(n_samples, file_name, simple), indent=4))
+            echo(json.dumps(eg.example(n_samples, file_name, simple, predefined), indent=4))
         else:
             eg.example(n_samples, file_name, simple)

--- a/ersilia/default.py
+++ b/ersilia/default.py
@@ -39,6 +39,7 @@ FETCHED_MODELS_FILENAME = "fetched_models.txt"
 MODEL_CONFIG_FILENAME = "config.json"
 EXAMPLE_STANDARD_INPUT_CSV_FILENAME = "example_standard_input.csv"
 EXAMPLE_STANDARD_OUTPUT_CSV_FILENAME = "example_standard_output.csv"
+PREDEFINED_EXAMPLE_FILENAME = "example.csv"
 DEFAULT_ERSILIA_ERROR_EXIT_CODE = 1
 METADATA_JSON_FILE = "metadata.json"
 SERVICE_CLASS_FILE = "service_class.txt"

--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -287,7 +287,12 @@ class ModelRepositoryGetter(BaseAction):
         file_name = os.path.join(self._model_path(self.model_id), "model", "framework", PREDEFINED_EXAMPLE_FILENAME)
         dest_file = os.path.join(self._model_path(self.model_id), PREDEFINED_EXAMPLE_FILENAME)
         if os.path.exists(file_name):
+            self.logger.debug("HERE!!!!")
+            self.logger.debug("Example file exists")
             shutil.copy(file_name, dest_file)
+        else:
+            self.logger.debug("HERE!!!!")
+            self.logger.debug("Example file {0} does not exist".format(file_name))
 
     @throw_ersilia_exception
     def get(self):

--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -17,7 +17,7 @@ from ....utils.exceptions_utils.fetch_exceptions import (
     S3DownloaderError,
 )
 
-from ....default import S3_BUCKET_URL_ZIP
+from ....default import S3_BUCKET_URL_ZIP, PREDEFINED_EXAMPLE_FILENAME
 
 MODEL_DIR = "model"
 ROOT = os.path.basename(os.path.abspath(__file__))
@@ -283,6 +283,12 @@ class ModelRepositoryGetter(BaseAction):
         self.logger.debug("Preparing inner template if necessary")
         TemplatePreparer(model_id=self.model_id, config_json=self.config_json).prepare()
 
+    def _copy_example_file_if_available(self):
+        file_name = os.path.join(self._model_path(self.model_id), "model", "framework", PREDEFINED_EXAMPLE_FILENAME)
+        dest_file = os.path.join(self._model_path(self.model_id), PREDEFINED_EXAMPLE_FILENAME)
+        if os.path.exists(file_name):
+            shutil.copy(file_name, dest_file)
+
     @throw_ersilia_exception
     def get(self):
         """Copy model repository from local or download from S3 or GitHub"""
@@ -314,6 +320,7 @@ class ModelRepositoryGetter(BaseAction):
         self._prepare_inner_template()
         self._change_py_version_in_dockerfile_if_necessary()
         self._remove_sudo_if_root()
+        self._copy_example_file_if_available()
 
 
 #  TODO: work outside GIT LFS

--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -287,11 +287,10 @@ class ModelRepositoryGetter(BaseAction):
         file_name = os.path.join(self._model_path(self.model_id), "model", "framework", PREDEFINED_EXAMPLE_FILENAME)
         dest_file = os.path.join(self._model_path(self.model_id), PREDEFINED_EXAMPLE_FILENAME)
         if os.path.exists(file_name):
-            self.logger.debug("HERE!!!!")
             self.logger.debug("Example file exists")
             shutil.copy(file_name, dest_file)
         else:
-            self.logger.debug("HERE!!!!")
+
             self.logger.debug("Example file {0} does not exist".format(file_name))
 
     @throw_ersilia_exception

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -2,7 +2,7 @@ from ..register.register import ModelRegisterer
 
 from .... import ErsiliaBase, throw_ersilia_exception
 from .... import EOS
-from ....default import DOCKERHUB_ORG, DOCKERHUB_LATEST_TAG
+from ....default import DOCKERHUB_ORG, DOCKERHUB_LATEST_TAG, PREDEFINED_EXAMPLE_FILENAME
 
 from ...pull.pull import ModelPuller
 from ....serve.services import PulledDockerImageService
@@ -75,6 +75,20 @@ class ModelDockerHubFetcher(ErsiliaBase):
             tag=DOCKERHUB_LATEST_TAG,
         )
 
+    def copy_example_if_available(self, model_id):
+        fr_file = "/root/eos/dest/{0}/model/framework/{1}".format(model_id, PREDEFINED_EXAMPLE_FILENAME)
+        to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, PREDEFINED_EXAMPLE_FILENAME)
+        try:
+            self.simple_docker.cp_from_image(
+                img_path=fr_file,
+                local_path=to_file,
+                org=DOCKERHUB_ORG,
+                img=model_id,
+                tag=DOCKERHUB_LATEST_TAG,
+            )
+        except:
+            self.logger.debug("Could not find example file in docker image")
+
     @throw_ersilia_exception
     def fetch(self, model_id):
         if not DockerRequirement().is_active():
@@ -87,3 +101,4 @@ class ModelDockerHubFetcher(ErsiliaBase):
         self.copy_information(model_id)
         self.copy_metadata(model_id)
         self.copy_status(model_id)
+        self.copy_example_if_available(model_id)

--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -179,7 +179,7 @@ class GenericInputAdapter(object):
 
 class ExampleGenerator(ErsiliaBase):
     def __init__(self, model_id, config_json=None):
-        self.check_model_id(model_id)
+        self.model_id = model_id
         self.IO = BaseIOGetter(config_json=config_json).get(model_id)
         ErsiliaBase.__init__(self, config_json=config_json)
         self.input_shape = self.IO.input_shape
@@ -260,9 +260,11 @@ class ExampleGenerator(ErsiliaBase):
         else:
             return False
 
-    def example(self, n_samples, file_name, simple, try_predefined=False):
+    def example(self, n_samples, file_name, simple, try_predefined):
         predefined_done = False
         if try_predefined is True and file_name is not None:
+            self.logger.debug("Trying with predefined input")
             predefined_done = self.predefined_example(file_name)
         if not predefined_done:
+            self.logger.debug("Randomly sampling input")
             self.random_example(n_samples=n_samples, file_name=file_name, simple=simple)

--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import json
 import csv
 import importlib
@@ -14,6 +15,8 @@ from .shape import InputShape
 from .shape import InputShapeSingle, InputShapeList, InputShapePairOfLists
 from .readers.pyinput import PyInputReader
 from .readers.file import TabularFileReader, JsonFileReader
+
+from ..default import PREDEFINED_EXAMPLE_FILENAME
 
 
 class BaseIOGetter(ErsiliaBase):
@@ -218,7 +221,7 @@ class ExampleGenerator(ErsiliaBase):
     def test(self):
         return self.IO.test()
 
-    def example(self, n_samples, file_name, simple):
+    def random_example(self, n_samples, file_name, simple):
         if not self._force_simple:
             simple = simple
         else:
@@ -247,3 +250,19 @@ class ExampleGenerator(ErsiliaBase):
                         writer.writerow(["key", "input", "text"])
                         for v in self.IO.example(n_samples):
                             writer.writerow([v["key"], v["input"], v["text"]])
+
+    def predefined_example(self, file_name):
+        dest_folder = self._model_path(self.model_id)
+        example_file = os.path.join(dest_folder, PREDEFINED_EXAMPLE_FILENAME)
+        if os.path.exists(example_file):
+            shutil.copy(example_file, file_name)
+            return True
+        else:
+            return False
+
+    def example(self, n_samples, file_name, simple, try_predefined=False):
+        predefined_done = False
+        if try_predefined is True and file_name is not None:
+            predefined_done = self.predefined_example(file_name)
+        if not predefined_done:
+            self.random_example(n_samples=n_samples, file_name=file_name, simple=simple)

--- a/ersilia/publish/test.py
+++ b/ersilia/publish/test.py
@@ -517,7 +517,6 @@ class ModelTester(ErsiliaBase):
                 print("VALUES:", values)
                 print(self._output_type)
                 if self._output_type == ["Float"]:
-                    print("FLOAT HERE")
                     values = [float(x) for x in values]
                 if self._output_type == ["Integer"]:
                     values = [int(x) for x in values]
@@ -671,7 +670,6 @@ class ModelTester(ErsiliaBase):
                     if isinstance(ersilia_run[i][column], (float, int)) and isinstance(
                         bash_run[i][column], (float, int)
                     ):
-                        print("HERE")
                         if not all(
                             self._compare_tolerance(a, b, DIFFERENCE_THRESHOLD)
                             for a, b in zip(ersilia_run[i][column], bash_run[i][column])
@@ -688,7 +686,6 @@ class ModelTester(ErsiliaBase):
                     elif isinstance(ersilia_run[i][column], str) and isinstance(
                         bash_run[i][column], str
                     ):
-                        print("THERE")
                         if not all(
                             self._compare_string_similarity(a, b, 95)
                             for a, b in zip(ersilia_run[i][column], bash_run[i][column])


### PR DESCRIPTION
In this PR we add `predefined` flag to the `ersilia example` command such that if an example file (`example.csv`) exists within a model's repository, the example command uses that instead of random sampling to generate model input examples. 

Refer to issues: https://github.com/ersilia-os/ersilia/issues/1100 and https://github.com/ersilia-os/eos-template/issues/40 for why this is relevant.