### PR TITLE
hotfix: pin requests to a version less than 2.31.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ fuzzywuzzy = {version = "^0.18.0", optional = true}
 sphinx = {version = ">=5.3.0", optional = true} # For compatibility with python 3.7.x
 jinja2 = {version = "^3.1.2", optional = true}
 boto3 = "^1.28.40"
-requests = "^2.31.0"
+requests = "<=2.31.0"
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
Requests which is currently set to ^2.31.0 installs 2.32.x which breaks docker_py as tracked [here](https://github.com/docker/docker-py/issues/3256).