### PR TITLE
Resolve duplication between RunLogger in ersilia/core/session.py and RunTracker in ersilia/core/tracking.py

### DIFF
--- a/ersilia/cli/commands/close.py
+++ b/ersilia/cli/commands/close.py
@@ -22,4 +22,4 @@ def close_cmd():
         echo(":no_entry: Model {0} closed".format(mdl.model_id), fg="green")
 
         # Close our persistent tracking file
-        close_persistent_file()
+        close_persistent_file(mdl.model_id)

--- a/ersilia/cli/commands/close.py
+++ b/ersilia/cli/commands/close.py
@@ -4,7 +4,7 @@ from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ...core.session import Session
-from ...core.tracking import close_persistent_file
+from ...core.tracking import check_file_exists, close_persistent_file
 
 
 def close_cmd():
@@ -22,4 +22,5 @@ def close_cmd():
         echo(":no_entry: Model {0} closed".format(mdl.model_id), fg="green")
 
         # Close our persistent tracking file
-        close_persistent_file(mdl.model_id)
+        if check_file_exists(model_id):
+            close_persistent_file(mdl.model_id)

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -3,7 +3,7 @@ from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ..messages import ModelNotFound
-from ...core.tracking import open_persistent_file
+from ...core.tracking import create_persistent_file
 
 
 def serve_cmd():
@@ -66,4 +66,4 @@ def serve_cmd():
 
         # Setup persistent tracking
         if track_serve:
-            open_persistent_file(mdl.model_id)
+            create_persistent_file(mdl.model_id)

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -11,7 +11,7 @@ import csv
 from .. import logger
 from .base import ErsiliaBase
 from .modelbase import ModelBase
-from .session import Session, RunLogger
+from .session import Session
 from .tracking import RunTracker
 from ..serve.autoservice import AutoService
 from ..serve.schema import ApiSchema
@@ -126,14 +126,14 @@ class ErsiliaModel(ErsiliaBase):
         self._set_apis()
         self.session = Session(config_json=self.config_json)
         if log_runs:
-            self._run_logger = RunLogger(
+            self._run_logger = RunTracker(
                 model_id=self.model_id, config_json=self.config_json
             )
         else:
             self._run_logger = None
 
         if track_runs:
-            self._run_tracker = RunTracker()
+            self._run_tracker = self._run_logger
         else:
             self._run_tracker = None
 
@@ -448,9 +448,9 @@ class ErsiliaModel(ErsiliaBase):
             api_name=api_name, input=input, output=output, batch_size=batch_size
         )
         if self._run_logger is not None:
-            self._run_logger.log(result=result, meta=self._model_info)
+            self._run_logger.log(result_path=result, meta=self._model_info)
         if self._run_tracker is not None and track_run:
-            self._run_tracker.track(input=input, result=result, meta=self._model_info)
+            self._run_tracker.track_run(input_path=input, result_path=result, meta=self._model_info)
         return result
 
     def _standard_run(self, input=None, output=None):
@@ -546,3 +546,4 @@ class ErsiliaModel(ErsiliaBase):
     @property
     def _model_info(self):
         return self.info()
+

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -448,9 +448,9 @@ class ErsiliaModel(ErsiliaBase):
             api_name=api_name, input=input, output=output, batch_size=batch_size
         )
         if self._run_logger is not None:
-            self._run_logger.log(result_path=result, meta=self._model_info)
+            self._run_logger.log(result=result, meta=self._model_info)
         if self._run_tracker is not None and track_run:
-            self._run_tracker.track_run(input_path=input, result_path=result, meta=self._model_info)
+            self._run_tracker.track(input=input, result=result, meta=self._model_info)
         return result
 
     def _standard_run(self, input=None, output=None):

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -448,9 +448,9 @@ class ErsiliaModel(ErsiliaBase):
             api_name=api_name, input=input, output=output, batch_size=batch_size
         )
         if self._run_logger is not None:
-            self._run_logger.log(result=result, meta=self._model_info)
+            self._run_logger.log(result_path=result, meta=self._model_info)
         if self._run_tracker is not None and track_run:
-            self._run_tracker.track(input=input, result=result, meta=self._model_info)
+            self._run_tracker.track_run(input_path=input, result_path=result, meta=self._model_info)
         return result
 
     def _standard_run(self, input=None, output=None):

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -6,10 +6,8 @@ import csv
 import shutil
 
 from .base import ErsiliaBase
-from ..io.output_logger import TabularResultLogger
 from ..default import EOS
 
-ERSILIA_RUNS_FOLDER = "ersilia_runs"
 
 
 class Session(ErsiliaBase):
@@ -68,56 +66,3 @@ class Session(ErsiliaBase):
         self.logger.debug("Closing session {0}".format(self.session_file))
         if os.path.isfile(self.session_file):
             os.remove(self.session_file)
-
-
-class RunLogger(ErsiliaBase):
-    def __init__(self, model_id, config_json):
-        ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
-        self.model_id = model_id
-        self.ersilia_runs_folder = os.path.join(EOS, ERSILIA_RUNS_FOLDER)
-        if not os.path.exists(self.ersilia_runs_folder):
-            os.mkdir(self.ersilia_runs_folder)
-        self.metadata_folder = os.path.join(self.ersilia_runs_folder, "metadata")
-        if not os.path.exists(self.metadata_folder):
-            os.mkdir(self.metadata_folder)
-        self.lake_folder = os.path.join(self.ersilia_runs_folder, "lake")
-        if not os.path.exists(self.lake_folder):
-            os.mkdir(self.lake_folder)
-        self.logs_folder = os.path.join(self.ersilia_runs_folder, "logs")
-        if not os.path.exists(self.logs_folder):
-            os.mkdir(self.logs_folder)
-        self.tabular_result_logger = TabularResultLogger()
-
-    def log_result(self, result):
-        output_dir = os.path.join(self.lake_folder, self.model_id)
-        if not os.path.exists(output_dir):
-            os.mkdir(output_dir)
-        file_name = os.path.join(output_dir, "{0}_lake.csv".format(self.model_id))
-        tabular_result = self.tabular_result_logger.tabulate(result)
-        if tabular_result is None:
-            return
-        with open(file_name, "w") as f:
-            writer = csv.writer(f, delimiter=",")
-            for r in tabular_result:
-                writer.writerow(r)
-
-    def log_meta(self, meta):
-        output_dir = os.path.join(self.metadata_folder, self.model_id)
-        if not os.path.exists(output_dir):
-            os.mkdir(output_dir)
-        file_name = os.path.join(output_dir, "{0}.json".format(self.model_id))
-        with open(file_name, "w") as f:
-            json.dump(meta, f)
-
-    def log_logs(self):
-        output_dir = os.path.join(self.logs_folder, self.model_id)
-        if not os.path.exists(output_dir):
-            os.mkdir(output_dir)
-        file_name = os.path.join(output_dir, "{0}.log".format(self.model_id))
-        session_file = os.path.join(EOS, "session.json")
-        shutil.copyfile(session_file, file_name)
-
-    def log(self, result, meta):
-        self.log_result(result)
-        self.log_meta(meta)
-        self.log_logs()

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -401,8 +401,6 @@ class RunTracker(ErsiliaBase):
             column_stats["max"] = max(values)
             column_stats["std"] = statistics.stdev(values) if len(values) > 1 else 0
 
-            stats[column] = column_stats
-
         return stats
         
         

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -1,19 +1,23 @@
-from datetime import datetime
+import os
 import json
+import sys
+import shutil
 import csv
+import logging
+import tracemalloc
 import statistics
 from collections import defaultdict
-import sys
-import tracemalloc
+from datetime import datetime
+from .base import ErsiliaBase
+from ..io.output_logger import TabularResultLogger
+from ..default import EOS, ERSILIA_RUNS_FOLDER 
 import tempfile
-import logging
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
-import os
 import re
 import requests
 
-PERSISTENT_FILE_PATH = os.path.abspath("current_session.txt")
+
 # Temporary path to log files until log files are fixed
 TEMP_FILE_LOGS = os.path.abspath("")
 
@@ -81,52 +85,72 @@ def log_files_metrics(file):
                 if misc_error_flag:
                     errors[error_name] += 1
 
-        write_persistent_file(f"Error count: {error_count}")
+        write_persistent_file(f"Error count: {error_count}", model_id)
         if len(errors) > 0:
-            write_persistent_file(f"Breakdown by error types:")
+            write_persistent_file(f"Breakdown by error types:", model_id)
             for error in errors:
-                write_persistent_file(f"{error}: {errors[error]}")
-        write_persistent_file(f"Warning count: {warning_count}")
+                write_persistent_file(f"{error}: {errors[error]}", model_id)
+        write_persistent_file(f"Warning count: {warning_count}", model_id)
     except (IsADirectoryError, FileNotFoundError):
         logging.warning("Unable to calculate metrics for log file: log file not found")
-        
+
+
+
+def persistent_file(model_id):
+
+    """
+    Create the persistent path file 
+    :param model_id: Te currently running model
+    """
+
+    persistent_file_dir = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id)
+    os.makedirs(persistent_file_dir, exist_ok=True)  
+    file_name = os.path.join(persistent_file_dir, "current_session.txt")
+    
+    return file_name
+
+    
 
 def open_persistent_file(model_id):
     """
     Opens a new persistent file, specifically for a run of model_id
     :param model_id: The currently running model
     """
-    with open(PERSISTENT_FILE_PATH, "w") as f:
+  
+    file_name = persistent_file(model_id)
+    with open(file_name, "w") as f:
         f.write("Session started for model: {0}\n".format(model_id))
         
         
-def write_persistent_file(contents):
+def write_persistent_file(contents, model_id):
+
     """
     Writes contents to the current persistent file. Only writes if the file actually exists.
     :param contents: The contents to write to the file.
     """
-
-    # Only write to file if it already exists (we're meant to be tracking this run)
-    if os.path.isfile(PERSISTENT_FILE_PATH):
-        with open(PERSISTENT_FILE_PATH, "a") as f:
+    
+    file_name = persistent_file(model_id)
+    if file_name and os.path.isfile(file_name):
+        with open(file_name, "a") as f:
             f.write(f"{contents}\n")
 
 
-def close_persistent_file():
+def close_persistent_file(model_id):
     """
     Closes the persistent file, renaming it to a unique name.
     """
-
-    # Make sure the file actually exists before we try renaming
-    if os.path.isfile(PERSISTENT_FILE_PATH):
+        
+    file_name = persistent_file(model_id)
+    if os.path.isfile(file_name):
         log_files_metrics(TEMP_FILE_LOGS)
 
         new_file_path = os.path.join(
-            os.path.dirname(PERSISTENT_FILE_PATH),
+            os.path.dirname(file_name),
             datetime.now().strftime("%Y-%m-%d%_H-%M-%S.txt"),
         )
-        os.rename(PERSISTENT_FILE_PATH, new_file_path)
+        os.rename(file_name, new_file_path)
         
+
 
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
     """Upload a file to an S3 bucket
@@ -228,6 +252,7 @@ def upload_to_cddvault(output_df, api_key):
         return False
 
 
+
 def read_csv(file_path):
     """
     Reads a CSV file and returns the data as a list of dictionaries.
@@ -239,6 +264,8 @@ def read_csv(file_path):
         reader = csv.DictReader(file)
         data = [row for row in reader]
     return data
+    
+    
 
 def get_nan_counts(data_list):
         """
@@ -263,35 +290,48 @@ def get_nan_counts(data_list):
                     nan_count[key] += 1
 
         return nan_count
+        
+class RunTracker(ErsiliaBase):
 
-
-class RunTracker:
     """
     This class will be responsible for tracking model runs. It calculates the desired metadata based on a model's
     inputs, outputs, and other run-specific features, before uploading them to AWS to be ingested
     to Ersilia's Splunk dashboard.
     """
-
-    def __init__(self):
+    
+    def __init__(self, model_id, config_json):
+        ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         self.time_start = None
         self.memory_usage_start = 0
+        self.model_id = model_id
 
-    # function to be called before model is run
+        # Initialize folders
+        self.ersilia_runs_folder = os.path.join(EOS, ERSILIA_RUNS_FOLDER)
+        os.makedirs(self.ersilia_runs_folder, exist_ok=True)
+        
+        self.metadata_folder = os.path.join(self.ersilia_runs_folder, "metadata")
+        os.makedirs(self.metadata_folder, exist_ok=True)
+        
+        self.lake_folder = os.path.join(self.ersilia_runs_folder, "lake")
+        os.makedirs(self.lake_folder, exist_ok=True)
+        
+        self.logs_folder = os.path.join(self.ersilia_runs_folder, "logs")
+        os.makedirs(self.logs_folder, exist_ok=True)
+        
+        self.tabular_result_logger = TabularResultLogger()
+        
+
     def start_tracking(self):
         """
-        Runs any code necessary for the beginning of the run.
-        Currently necessary for tracking the runtime and memory usage of a run.
-        """
+	Runs any code necessary for the beginning of the run.
+	Currently necessary for tracking the runtime and memory usage of a run.
+	
+	"""
         self.time_start = datetime.now()
         tracemalloc.start()
         self.memory_usage_start = tracemalloc.get_traced_memory()[0]
-
-    def sample_df(self, df, num_rows, num_cols):
-        """
-        Returns a sample of the dataframe, with the specified number of rows and columns.
-        """
-        return df.sample(num_rows, axis=0).sample(num_cols, axis=1)
-
+        
+        
     def stats(self, result):
         """
         Stats function: calculates the basic statistics of the output file from a model. This includes the
@@ -330,7 +370,8 @@ class RunTracker:
             stats[column] = column_stats
 
         return stats
-    
+        
+        
     def get_file_sizes(self, input_file, output_file):
         """
         Calculates the size of the input and output dataframes, as well as the average size of each row.
@@ -352,7 +393,8 @@ class RunTracker:
             "avg_input_size": input_avg_row_size,
             "avg_output_size": output_avg_row_size,
         }
-    
+        
+        
     def check_types(self, result, metadata):
         """
         This method is responsible for checking the types of the output file against the expected types.
@@ -393,55 +435,81 @@ class RunTracker:
 
         return {"mismatched_types": count, "correct_shape": correct_shape}
         
+        
+        
     def get_peak_memory(self):
         """
-        Calculates the peak memory usage of ersilia's Python instance during the run.
-        :return: The peak memory usage in bytes.
-        """
-
-        # Compare memory between peak and amount when we started
+	Calculates the peak memory usage of ersilia's Python instance during the run.
+	:return: The peak memory usage in bytes.
+	"""
         peak_memory = tracemalloc.get_traced_memory()[1] - self.memory_usage_start
         tracemalloc.stop()
-
         return peak_memory
-    
+
+
+    def log_result(self, result):
+        output_dir = os.path.join(self.lake_folder, self.model_id)
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+        file_name = os.path.join(output_dir, "{0}_lake.csv".format(self.model_id))
+        tabular_result = self.tabular_result_logger.tabulate(result)
+        if tabular_result is None:
+            return
+        with open(file_name, "w") as f:
+            writer = csv.writer(f, delimiter=",")
+            for r in tabular_result:
+                writer.writerow(r)
+
+    def log_meta(self, meta):
+        output_dir = os.path.join(self.metadata_folder, self.model_id)
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+        file_name = os.path.join(output_dir, "{0}.json".format(self.model_id))
+        with open(file_name, "w") as f:
+            json.dump(meta, f)
+
+    def log_logs(self):
+        output_dir = os.path.join(self.logs_folder, self.model_id)
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+        file_name = os.path.join(output_dir, "{0}.log".format(self.model_id))
+        session_file = os.path.join(EOS, "session.json")
+        shutil.copyfile(session_file, file_name)
 
     def track(self, input, result, meta):
         """
-        Tracks the results after a model run.
-        """
+    	Tracks the results of a model run.
+    	"""
+        self.start_tracking()
         json_dict = {}
         input_data = read_csv(input)
         result_data = read_csv(result)
 
-        json_dict["input_data"] = input_data
-        json_dict["result_data"] = result_data
-
-        json_dict["meta"] = meta
-
         model_id = meta["metadata"].get("Identifier", "Unknown")
         json_dict["model_id"] = model_id
 
-        time = datetime.now() - self.time_start
-        json_dict["time_taken"] = str(time)
+        time_taken = datetime.now() - self.time_start
+        json_dict["time_taken"] = str(time_taken)
 
         # checking for mismatched types
         nan_count = get_nan_counts(result_data)
         json_dict["nan_count"] = nan_count
-
+        
         json_dict["check_types"] = self.check_types(result_data, meta["metadata"])
-
+        
         json_dict["stats"] = self.stats(result)
 
         json_dict["file_sizes"] = self.get_file_sizes(input_data, result_data)
-
+         
         json_dict["peak_memory_use"] = self.get_peak_memory()
 
-        # TODO: Call CDD Vault tracking and upload API success to splunk
-
-        # log results to persistent tracking file
         json_object = json.dumps(json_dict, indent=4)
-        write_persistent_file(json_object)
-
-        # Upload run stats to s3
+        write_persistent_file(json_object, model_id)
         upload_to_s3(json_dict)
+
+    # Log results, metadata, and session logs
+    def log(self, result, meta):
+        self.log_result(result)
+        self.log_meta(meta)
+        self.log_logs()
+        

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -110,37 +110,51 @@ def create_persistent_file(model_id):
     with open(file_name, "w") as f:
         f.write("Session started for model: {0}\n".format(model_id))
     
-    return file_name
 
+def check_file_exists(model_id):
+    """
+    Check if the persistent file exists.
+    :param model_id: The currently running model
+    :return: True if the file exists, False otherwise.
+    """
+    persistent_file_dir = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id)
+    file_name = os.path.join(persistent_file_dir, "current_session.txt")
+    return os.path.isfile(file_name)
     
+       
         
 def write_persistent_file(contents, model_id):
-
     """
     Writes contents to the current persistent file. Only writes if the file actually exists.
     :param contents: The contents to write to the file.
+    :param model_id: The currently running model
     """
-    
-    file_name = create_persistent_file(model_id)
-    if file_name and os.path.isfile(file_name):
+    if check_file_exists(model_id):
+        file_name = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt")
         with open(file_name, "a") as f:
             f.write(f"{contents}\n")
 
-
+    else:
+        raise FileNotFoundError(f"The persistent file for model {model_id} does not exist. Cannot write contents.")
+        
+        
 def close_persistent_file(model_id):
     """
     Closes the persistent file, renaming it to a unique name.
+    :param model_id: The currently running model
     """
+    if check_file_exists(model_id):
+        file_name = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt")
+        log_files_metrics(TEMP_FILE_LOGS)  # Assuming this function is defined elsewhere
         
-    file_name = create_persistent_file(model_id)
-    if os.path.isfile(file_name):
-        log_files_metrics(TEMP_FILE_LOGS)
-
         new_file_path = os.path.join(
             os.path.dirname(file_name),
-            datetime.now().strftime("%Y-%m-%d%_H-%M-%S.txt"),
+            datetime.now().strftime("%Y-%m-%d_%H-%M-%S.txt"),
         )
         os.rename(file_name, new_file_path)
+        
+    else:
+        raise FileNotFoundError(f"The persistent file for model {model_id} does not exist. Cannot close file.")
         
 
 

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -484,7 +484,7 @@ class RunTracker(ErsiliaBase):
         json_dict = {}
         input_data = read_csv(input)
         result_data = read_csv(result)
-
+        
         model_id = meta["metadata"].get("Identifier", "Unknown")
         json_dict["model_id"] = model_id
 
@@ -512,4 +512,3 @@ class RunTracker(ErsiliaBase):
         self.log_result(result)
         self.log_meta(meta)
         self.log_logs()
-        

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -18,13 +18,6 @@ import re
 import requests
 
 
-<<<<<<< HEAD
-=======
-
-PERSISTENT_FILE_PATH = None
-
-
->>>>>>> 6c918d3c (Reroute session file to the EOS directory)
 # Temporary path to log files until log files are fixed
 TEMP_FILE_LOGS = os.path.abspath("")
 
@@ -119,49 +112,26 @@ def persistent_file(model_id):
     
 
 def open_persistent_file(model_id):
-
     """
     Opens a new persistent file, specifically for a run of model_id
     :param model_id: The currently running model
     """
-<<<<<<< HEAD
   
     file_name = persistent_file(model_id)
     with open(file_name, "w") as f:
-=======
-    global PERSISTENT_FILE_PATH
-    persistent_file_dir = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id)
-    os.makedirs(persistent_file_dir, exist_ok=True)  
-    PERSISTENT_FILE_PATH = os.path.join(persistent_file_dir, "current_session.txt")
-    with open(PERSISTENT_FILE_PATH, "w") as f:
->>>>>>> 6c918d3c (Reroute session file to the EOS directory)
         f.write("Session started for model: {0}\n".format(model_id))
         
         
 def write_persistent_file(contents, model_id):
 
-<<<<<<< HEAD
-=======
-
-def write_persistent_file(contents):
-
->>>>>>> 6c918d3c (Reroute session file to the EOS directory)
     """
     Writes contents to the current persistent file. Only writes if the file actually exists.
     :param contents: The contents to write to the file.
     """
-<<<<<<< HEAD
     
     file_name = persistent_file(model_id)
     if file_name and os.path.isfile(file_name):
         with open(file_name, "a") as f:
-=======
-	
-    # Only write to file if it already exists (we're meant to be tracking this run)
-    global PERSISTENT_FILE_PATH
-    if PERSISTENT_FILE_PATH and os.path.isfile(PERSISTENT_FILE_PATH):
-        with open(PERSISTENT_FILE_PATH, "a") as f:
->>>>>>> 6c918d3c (Reroute session file to the EOS directory)
             f.write(f"{contents}\n")
 
 
@@ -349,10 +319,6 @@ class RunTracker(ErsiliaBase):
         os.makedirs(self.logs_folder, exist_ok=True)
         
         self.tabular_result_logger = TabularResultLogger()
-<<<<<<< HEAD
-=======
-        self.PERSISTENT_FILE_PATH = open_persistent_file(model_id)
->>>>>>> 6c918d3c (Reroute session file to the EOS directory)
         
 
     def start_tracking(self):
@@ -400,6 +366,8 @@ class RunTracker(ErsiliaBase):
             column_stats["min"] = min(values)
             column_stats["max"] = max(values)
             column_stats["std"] = statistics.stdev(values) if len(values) > 1 else 0
+
+            stats[column] = column_stats
 
         return stats
         
@@ -516,7 +484,7 @@ class RunTracker(ErsiliaBase):
         json_dict = {}
         input_data = read_csv(input)
         result_data = read_csv(result)
-        
+
         model_id = meta["metadata"].get("Identifier", "Unknown")
         json_dict["model_id"] = model_id
 

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -96,31 +96,23 @@ def log_files_metrics(file):
 
 
 
-def persistent_file(model_id):
+def create_persistent_file(model_id):
 
     """
     Create the persistent path file 
-    :param model_id: Te currently running model
+    :param model_id: The currently running model
     """
 
     persistent_file_dir = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id)
     os.makedirs(persistent_file_dir, exist_ok=True)  
     file_name = os.path.join(persistent_file_dir, "current_session.txt")
     
+    with open(file_name, "w") as f:
+        f.write("Session started for model: {0}\n".format(model_id))
+    
     return file_name
 
     
-
-def open_persistent_file(model_id):
-    """
-    Opens a new persistent file, specifically for a run of model_id
-    :param model_id: The currently running model
-    """
-  
-    file_name = persistent_file(model_id)
-    with open(file_name, "w") as f:
-        f.write("Session started for model: {0}\n".format(model_id))
-        
         
 def write_persistent_file(contents, model_id):
 
@@ -129,7 +121,7 @@ def write_persistent_file(contents, model_id):
     :param contents: The contents to write to the file.
     """
     
-    file_name = persistent_file(model_id)
+    file_name = create_persistent_file(model_id)
     if file_name and os.path.isfile(file_name):
         with open(file_name, "a") as f:
             f.write(f"{contents}\n")
@@ -140,7 +132,7 @@ def close_persistent_file(model_id):
     Closes the persistent file, renaming it to a unique name.
     """
         
-    file_name = persistent_file(model_id)
+    file_name = create_persistent_file(model_id)
     if os.path.isfile(file_name):
         log_files_metrics(TEMP_FILE_LOGS)
 

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -18,6 +18,13 @@ import re
 import requests
 
 
+<<<<<<< HEAD
+=======
+
+PERSISTENT_FILE_PATH = None
+
+
+>>>>>>> 6c918d3c (Reroute session file to the EOS directory)
 # Temporary path to log files until log files are fixed
 TEMP_FILE_LOGS = os.path.abspath("")
 
@@ -112,26 +119,49 @@ def persistent_file(model_id):
     
 
 def open_persistent_file(model_id):
+
     """
     Opens a new persistent file, specifically for a run of model_id
     :param model_id: The currently running model
     """
+<<<<<<< HEAD
   
     file_name = persistent_file(model_id)
     with open(file_name, "w") as f:
+=======
+    global PERSISTENT_FILE_PATH
+    persistent_file_dir = os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id)
+    os.makedirs(persistent_file_dir, exist_ok=True)  
+    PERSISTENT_FILE_PATH = os.path.join(persistent_file_dir, "current_session.txt")
+    with open(PERSISTENT_FILE_PATH, "w") as f:
+>>>>>>> 6c918d3c (Reroute session file to the EOS directory)
         f.write("Session started for model: {0}\n".format(model_id))
         
         
 def write_persistent_file(contents, model_id):
 
+<<<<<<< HEAD
+=======
+
+def write_persistent_file(contents):
+
+>>>>>>> 6c918d3c (Reroute session file to the EOS directory)
     """
     Writes contents to the current persistent file. Only writes if the file actually exists.
     :param contents: The contents to write to the file.
     """
+<<<<<<< HEAD
     
     file_name = persistent_file(model_id)
     if file_name and os.path.isfile(file_name):
         with open(file_name, "a") as f:
+=======
+	
+    # Only write to file if it already exists (we're meant to be tracking this run)
+    global PERSISTENT_FILE_PATH
+    if PERSISTENT_FILE_PATH and os.path.isfile(PERSISTENT_FILE_PATH):
+        with open(PERSISTENT_FILE_PATH, "a") as f:
+>>>>>>> 6c918d3c (Reroute session file to the EOS directory)
             f.write(f"{contents}\n")
 
 
@@ -319,6 +349,10 @@ class RunTracker(ErsiliaBase):
         os.makedirs(self.logs_folder, exist_ok=True)
         
         self.tabular_result_logger = TabularResultLogger()
+<<<<<<< HEAD
+=======
+        self.PERSISTENT_FILE_PATH = open_persistent_file(model_id)
+>>>>>>> 6c918d3c (Reroute session file to the EOS directory)
         
 
     def start_tracking(self):
@@ -512,3 +546,4 @@ class RunTracker(ErsiliaBase):
         self.log_result(result)
         self.log_meta(meta)
         self.log_logs()
+        

--- a/ersilia/default.py
+++ b/ersilia/default.py
@@ -49,6 +49,7 @@ IS_FETCHED_FROM_DOCKERHUB_FILE = "from_dockerhub.json"
 IS_FETCHED_FROM_HOSTED_FILE = "from_hosted.json"
 DEFAULT_UDOCKER_USERNAME = "udockerusername"
 DEFAULT_UDOCKER_PASSWORD = "udockerpassword"
+ERSILIA_RUNS_FOLDER = "ersilia_runs"
 
 # Isaura data lake
 H5_EXTENSION = ".h5"


### PR DESCRIPTION
**Description**

Resolve duplication between RunLogger in ersilia/core/session.py and RunTracker in ersilia/core/tracking.py. For example, both RunTracker and RunLogger subsample result output when the output dimensions are too many to reduce storage overhead and to not clutter the monitoring dashboard.


**Changes Made**

- Runlogger Class merged to the RunTracker classes in tracking.py,  creating a new unified class that inherits from both base classes and includes the initialization logic for both.
- Created a single __init__ method that handles the initialization requirement for tracking and logging.
- Dropped the `sample_df` method, and modified modified most of the functions in the RunTracker class. 
- Created a `track_run` function with clearer method names and simplified parameters, excluding input and result data frames, meta, and metadata from the JSON output.
- Changed the session file path to be under ersilia_runs.
- Modified `model.py` to reflect the changes.


**Status**

- The tracking module works with the changes made.
- The size of the JSON object has been significantly reduced (more than 10 times), and potential issues with large DataFrames have been avoided.
- The session file is now rerouted to the same directory used by the rest of the logging and tracking files.
- The memory usage during the model run was also reduced.

Related to https://github.com/ersilia-os/ersilia/issues/1090