### PR TITLE
fix: relax regex search of docker logs

### DIFF
--- a/ersilia/hub/pull/pull.py
+++ b/ersilia/hub/pull/pull.py
@@ -119,7 +119,7 @@ class ModelPuller(ErsiliaBase):
                 with open(tmp_file, "r") as f:
                     pull_log = f.read()
                     self.logger.debug(pull_log)
-                if re.search(r"no match.*platform.*manifest", pull_log):
+                if re.search(r"no match.*manifest", pull_log):
                     self.logger.warning("No matching manifest for image {0}".format(self.model_id))
                     raise DockerConventionalPullError(model=self.model_id)
                 self.logger.debug("Image pulled succesfully!")


### PR DESCRIPTION
Addresses #1156 

Docker output log from failed pull on apple silicon is:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

current regex is:
```
r"no match.*platform.*manifest"
```

there's no 'platform' in this message so we won't match; we should remove the match on 'platform'