### PR TITLE
Remove multiple and redundant track flags

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -21,35 +21,35 @@ def run_cmd():
         "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
     )
     @click.option(
-        "-t/", "--track_run/--no_track_run", "track_run", required=False, default=False
-    )
-    @click.option(
         "--standard",
         is_flag=True,
         default=False,
         help="Assume that the run is standard and, therefore, do not do so many checks.",
     )
-    def run(input, output, batch_size, track_run, standard):
+    def run(input, output, batch_size, standard):
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
+        track_status=session.tracking_status()
+        
         if model_id is None:
             echo(
                 "No model seems to be served. Please run 'ersilia serve ...' before.",
                 fg="red",
             )
             return
+        
         mdl = ErsiliaModel(
             model_id,
             service_class=service_class,
             config_json=None,
-            track_runs=track_run,
+            track_status=track_status,
         )
         result = mdl.run(
             input=input,
             output=output,
             batch_size=batch_size,
-            track_run=track_run,
+            track_run=track_status,
             try_standard=standard,
         )
         if isinstance(result, types.GeneratorType):

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -30,28 +30,29 @@ def run_cmd():
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
-        track_status=session.tracking_status()
-        
+        track_runs = session.tracking_status()
+
         if model_id is None:
             echo(
                 "No model seems to be served. Please run 'ersilia serve ...' before.",
                 fg="red",
             )
             return
-        
+
         mdl = ErsiliaModel(
             model_id,
             service_class=service_class,
             config_json=None,
-            track_status=track_status,
+            track_runs=track_runs,
         )
         result = mdl.run(
             input=input,
             output=output,
             batch_size=batch_size,
-            track_run=track_status,
+            track_run=track_runs,
             try_standard=standard,
         )
+
         if isinstance(result, types.GeneratorType):
             for result in mdl.run(input=input, output=output, batch_size=batch_size):
                 if result is not None:

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -23,19 +23,21 @@ def serve_cmd():
     )
     # Add the new flag for tracking the serve session
     @click.option(
-        "-t/",
-        "--track_serve/--no_track_serve",
-        "track_serve",
+        "-t",
+        "--track",
+        "track",
+        is_flag=True,
         required=False,
         default=False,
     )
-    def serve(model, lake, docker, port, track_serve):
+    def serve(model, lake, docker, port, track):
         if docker:
             service_class = "docker"
         else:
             service_class = None
         mdl = ErsiliaModel(
-            model, save_to_lake=lake, service_class=service_class, preferred_port=port
+            model, save_to_lake=lake, service_class=service_class, preferred_port=port,
+            track_status=track
         )
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
@@ -65,5 +67,8 @@ def serve_cmd():
         echo("   - info", fg="blue")
 
         # Setup persistent tracking
-        if track_serve:
+        if track:
             create_persistent_file(mdl.model_id)
+
+
+

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -36,8 +36,11 @@ def serve_cmd():
         else:
             service_class = None
         mdl = ErsiliaModel(
-            model, save_to_lake=lake, service_class=service_class, preferred_port=port,
-            track_status=track
+            model,
+            save_to_lake=lake,
+            service_class=service_class,
+            preferred_port=port,
+            track_runs=track,
         )
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
@@ -69,6 +72,3 @@ def serve_cmd():
         # Setup persistent tracking
         if track:
             create_persistent_file(mdl.model_id)
-
-
-

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -49,7 +49,7 @@ class ErsiliaModel(ErsiliaBase):
         fetch_if_not_available=True,
         preferred_port=None,
         log_runs=True,
-        track_status=False,
+        track_runs=False,
     ):
         ErsiliaBase.__init__(
             self, config_json=config_json, credentials_json=credentials_json
@@ -81,7 +81,7 @@ class ErsiliaModel(ErsiliaBase):
             "hosted",
         ], "Wrong service class"
         self.service_class = service_class
-        self.track_status=track_status
+        self.track_runs = track_runs
         mdl = ModelBase(model)
         self._is_valid = mdl.is_valid()
         assert (
@@ -133,7 +133,7 @@ class ErsiliaModel(ErsiliaBase):
         else:
             self._run_logger = None
 
-        if track_status:
+        if track_runs:
             self._run_tracker = self._run_logger
         else:
             self._run_tracker = None
@@ -422,10 +422,9 @@ class ErsiliaModel(ErsiliaBase):
 
     def serve(self):
         self.close()
-        self.session.open(model_id=self.model_id,track_status=self.track_status)
+        self.session.open(model_id=self.model_id, track_runs=self.track_runs)
         self.autoservice.serve()
         self.session.register_service_class(self.autoservice._service_class)
-        self.session.register_tracking_status(self.track_status)
         self.url = self.autoservice.service.url
         self.pid = self.autoservice.service.pid
         self.scl = self.autoservice._service_class
@@ -548,4 +547,3 @@ class ErsiliaModel(ErsiliaBase):
     @property
     def _model_info(self):
         return self.info()
-

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -49,7 +49,7 @@ class ErsiliaModel(ErsiliaBase):
         fetch_if_not_available=True,
         preferred_port=None,
         log_runs=True,
-        track_runs=False,
+        track_status=False,
     ):
         ErsiliaBase.__init__(
             self, config_json=config_json, credentials_json=credentials_json
@@ -81,6 +81,7 @@ class ErsiliaModel(ErsiliaBase):
             "hosted",
         ], "Wrong service class"
         self.service_class = service_class
+        self.track_status=track_status
         mdl = ModelBase(model)
         self._is_valid = mdl.is_valid()
         assert (
@@ -132,7 +133,7 @@ class ErsiliaModel(ErsiliaBase):
         else:
             self._run_logger = None
 
-        if track_runs:
+        if track_status:
             self._run_tracker = self._run_logger
         else:
             self._run_tracker = None
@@ -421,9 +422,10 @@ class ErsiliaModel(ErsiliaBase):
 
     def serve(self):
         self.close()
-        self.session.open(model_id=self.model_id)
+        self.session.open(model_id=self.model_id,track_status=self.track_status)
         self.autoservice.serve()
         self.session.register_service_class(self.autoservice._service_class)
+        self.session.register_tracking_status(self.track_status)
         self.url = self.autoservice.service.url
         self.pid = self.autoservice.service.pid
         self.scl = self.autoservice._service_class

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -42,12 +42,26 @@ class Session(ErsiliaBase):
         with open(self.session_file, "w") as f:
             json.dump(data, f, indent=4)
 
-    def open(self, model_id):
+    def tracking_status(self):
+        data = self.get()
+        if data is None:
+            return None
+        else:
+            return data["track_status"]
+
+    def register_tracking_status(self, track_status):
+        data = self.get()
+        data["track_status"] = track_status
+        with open(self.session_file, "w") as f:
+            json.dump(data, f, indent=4)
+
+    def open(self, model_id,track_status):
         self.logger.debug("Opening session {0}".format(self.session_file))
         session = {
             "model_id": model_id,
             "timestamp": str(time.time()),
             "identifier": str(uuid.uuid4()),
+            "track_status":track_status
         }
         with open(self.session_file, "w") as f:
             json.dump(session, f, indent=4)
@@ -66,3 +80,6 @@ class Session(ErsiliaBase):
         self.logger.debug("Closing session {0}".format(self.session_file))
         if os.path.isfile(self.session_file):
             os.remove(self.session_file)
+
+
+

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -9,7 +9,6 @@ from .base import ErsiliaBase
 from ..default import EOS
 
 
-
 class Session(ErsiliaBase):
     def __init__(self, config_json):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
@@ -47,21 +46,15 @@ class Session(ErsiliaBase):
         if data is None:
             return None
         else:
-            return data["track_status"]
+            return data["track_runs"]
 
-    def register_tracking_status(self, track_status):
-        data = self.get()
-        data["track_status"] = track_status
-        with open(self.session_file, "w") as f:
-            json.dump(data, f, indent=4)
-
-    def open(self, model_id,track_status):
+    def open(self, model_id, track_runs):
         self.logger.debug("Opening session {0}".format(self.session_file))
         session = {
             "model_id": model_id,
             "timestamp": str(time.time()),
             "identifier": str(uuid.uuid4()),
-            "track_status":track_status
+            "track_runs": track_runs,
         }
         with open(self.session_file, "w") as f:
             json.dump(session, f, indent=4)
@@ -80,6 +73,3 @@ class Session(ErsiliaBase):
         self.logger.debug("Closing session {0}".format(self.session_file))
         if os.path.isfile(self.session_file):
             os.remove(self.session_file)
-
-
-


### PR DESCRIPTION
**Description**

Remove multiple, redundant tracking flags and keep a single boolean flag with a default false value, such that by default we do not track runs for now.

**Changes to be made**

Change the `track_serve` flag to `track` and ensure it tracks the session without the need to use `track_run` again.
Remove the `track_run` flag
Compare the output with the output of the former state.

**Status**
Successfully changed the multiple track flags into one (`track`)
track flag has been moved to serve

**To do**
Confirm that the metrics of several run sessions of the same model are appended to the same file

Related to #1158 #1090