### PR TITLE
Rework code calculating memory usage - output and Docker container

### DIFF
--- a/ersilia/cli/commands/close.py
+++ b/ersilia/cli/commands/close.py
@@ -4,7 +4,7 @@ from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ...core.session import Session
-from ...core.tracking import check_file_exists, close_persistent_file
+from ...core.tracking import check_file_exists,  close_persistent_file
 
 
 def close_cmd():
@@ -23,4 +23,4 @@ def close_cmd():
 
         # Close our persistent tracking file
         if check_file_exists(model_id):
-            close_persistent_file(mdl.model_id)
+           close_persistent_file(mdl.model_id)

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -6,7 +6,6 @@ from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ...core.session import Session
-from ...core.tracking import RunTracker
 
 
 def run_cmd():
@@ -62,4 +61,3 @@ def run_cmd():
                     echo("Something went wrong", fg="red")
         else:
             echo(result)
-

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -6,6 +6,7 @@ from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ...core.session import Session
+from ...core.tracking import RunTracker
 
 
 def run_cmd():
@@ -61,3 +62,4 @@ def run_cmd():
                     echo("Something went wrong", fg="red")
         else:
             echo(result)
+

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -5,6 +5,7 @@ from . import ersilia_cli
 from ... import ErsiliaModel
 from ..messages import ModelNotFound
 
+
 def serve_cmd():
     """Creates serve command"""
 
@@ -40,7 +41,6 @@ def serve_cmd():
             service_class=service_class,
             preferred_port=port,
             track_runs=track,
-
         )
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -1,10 +1,9 @@
 import click
-from . import ersilia_cli
+
 from .. import echo
+from . import ersilia_cli
 from ... import ErsiliaModel
 from ..messages import ModelNotFound
-from ...core.tracking import create_persistent_file
-
 
 def serve_cmd():
     """Creates serve command"""
@@ -41,6 +40,7 @@ def serve_cmd():
             service_class=service_class,
             preferred_port=port,
             track_runs=track,
+
         )
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
@@ -68,7 +68,3 @@ def serve_cmd():
         echo("")
         echo(":person_tipping_hand: Information:", fg="blue")
         echo("   - info", fg="blue")
-
-        # Setup persistent tracking
-        if track:
-            create_persistent_file(mdl.model_id)

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -1,33 +1,32 @@
 import os
-import json
-import tempfile
-import types
-import collections
-import importlib
-import __main__ as main
-import time
 import csv
+import json
+import time
+import types
+import tempfile
+import importlib
+import collections
+import __main__ as main
 
 from .. import logger
-from .base import ErsiliaBase
-from .modelbase import ModelBase
-from .session import Session
-from .tracking import RunTracker
-from ..serve.autoservice import AutoService
-from ..serve.schema import ApiSchema
 from ..serve.api import Api
-from ..serve.standard_api import StandardCSVRunApi
-from ..io.input import ExampleGenerator, BaseIOGetter
-from ..io.output import TabularOutputStacker
-from ..io.readers.file import FileTyper, TabularFileReader
+from .session import Session
+from datetime import datetime
+from .base import ErsiliaBase
+from ..lake.base import LakeBase
 from ..utils import tmp_pid_file
+from .modelbase import ModelBase
+from ..serve.schema import ApiSchema
 from ..utils.hdf5 import Hdf5DataLoader
 from ..utils.csvfile import CsvDataLoader
 from ..utils.terminal import yes_no_input
-from ..lake.base import LakeBase
-
+from ..serve.autoservice import AutoService
+from ..io.output import TabularOutputStacker
+from ..serve.standard_api import StandardCSVRunApi
+from ..io.input import ExampleGenerator, BaseIOGetter
+from .tracking import RunTracker, create_persistent_file
+from ..io.readers.file import FileTyper, TabularFileReader
 from ..utils.exceptions_utils.api_exceptions import ApiSpecifiedOutputError
-
 from ..default import FETCHED_MODELS_FILENAME, MODEL_SIZE_FILE, CARD_FILE, EOS
 from ..default import DEFAULT_BATCH_SIZE, APIS_LIST_FILE, INFORMATION_FILE
 
@@ -48,8 +47,8 @@ class ErsiliaModel(ErsiliaBase):
         verbose=None,
         fetch_if_not_available=True,
         preferred_port=None,
-        log_runs=True,
         track_runs=False,
+        track_serve=False
     ):
         ErsiliaBase.__init__(
             self, config_json=config_json, credentials_json=credentials_json
@@ -126,15 +125,11 @@ class ErsiliaModel(ErsiliaBase):
         )
         self._set_apis()
         self.session = Session(config_json=self.config_json)
-        if log_runs:
-            self._run_logger = RunTracker(
+        
+        if track_runs or track_serve:
+            self._run_tracker = RunTracker(
                 model_id=self.model_id, config_json=self.config_json
             )
-        else:
-            self._run_logger = None
-
-        if track_runs:
-            self._run_tracker = self._run_logger
         else:
             self._run_tracker = None
 
@@ -420,7 +415,11 @@ class ErsiliaModel(ErsiliaBase):
             for key, values in models.items():
                 f.write(f"{key},{values}\n")
 
+   
     def serve(self):
+        # Start tracking to get the peak memory in serve
+        if self._run_tracker is not None:
+            create_persistent_file(self.model_id)
         self.close()
         self.session.open(model_id=self.model_id, track_runs=self.track_runs)
         self.autoservice.serve()
@@ -429,6 +428,17 @@ class ErsiliaModel(ErsiliaBase):
         self.pid = self.autoservice.service.pid
         self.scl = self.autoservice._service_class
         # self.update_model_usage_time(self.model_id) TODO: Check and reactivate
+        
+        # Get the memory usage and cpu time of the Model server(autoservice)
+        if self._run_tracker is not None:
+
+            memory_usage_serve, cpu_time_serve = self._run_tracker.get_memory_info()
+            peak_memory_serve = self._run_tracker.get_peak_memory()
+
+            session = Session(config_json=None)
+            session.update_peak_memory(peak_memory_serve)
+            session.update_total_memory(memory_usage_serve)
+            session.update_cpu_time(cpu_time_serve)
 
     def close(self):
         self.autoservice.close()
@@ -440,18 +450,12 @@ class ErsiliaModel(ErsiliaBase):
     def _run(
         self, input=None, output=None, batch_size=DEFAULT_BATCH_SIZE, track_run=False
     ):
-        # Init some tracking before the run starts
-        if self._run_tracker is not None and track_run:
-            self._run_tracker.start_tracking()
 
         api_name = self.get_apis()[0]
         result = self.api(
             api_name=api_name, input=input, output=output, batch_size=batch_size
         )
-        if self._run_logger is not None:
-            self._run_logger.log(result=result, meta=self._model_info)
-        if self._run_tracker is not None and track_run:
-            self._run_tracker.track(input=input, result=result, meta=self._model_info)
+       
         return result
 
     def _standard_run(self, input=None, output=None):
@@ -497,6 +501,10 @@ class ErsiliaModel(ErsiliaBase):
             result = self._run(
                 input=input, output=output, batch_size=batch_size, track_run=track_run
             )
+            # Start tracking model run
+            if self._run_tracker is not None and track_run:
+                self._run_tracker.track(input=input, result=result, meta=self._model_info)
+                self._run_tracker.log(result=result, meta=self._model_info)               
             return result
 
     @property

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -1,12 +1,13 @@
+import os
+import csv
 import json
 import time
 import uuid
-import os
-import csv
 import shutil
 
-from .base import ErsiliaBase
 from ..default import EOS
+from .base import ErsiliaBase
+
 
 
 class Session(ErsiliaBase):
@@ -69,7 +70,50 @@ class Session(ErsiliaBase):
             self.logger.debug("No session exists")
             return None
 
+
+    def update_total_memory(self, additional_memory):
+        """
+        Methods to get the the total memory of processess during serving and running.
+        """
+        data = self.get()
+        if data is None:
+            data = {}
+        current_memory = float(data.get("total memory used by model(MB)", 0))
+        new_memory = current_memory + additional_memory
+        data["total memory used by model(MB)"] = f"{new_memory:.5f}"
+        with open(self.session_file, "w") as f:
+            json.dump(data, f, indent=4)
+    
+    def update_cpu_time(self, cpu_time):
+        """
+        Methods to get the total cpu time of processess during serving and running
+        """
+        data = self.get()
+        if data is None:
+            data = {}
+        current_cpu = float(data.get("CPU time used by model(seconds)", 0))
+        new_cpu = current_cpu + cpu_time
+        data["CPU time used by model(seconds)"] = f"{new_cpu}"       
+        with open(self.session_file, "w") as f:
+            json.dump(data, f, indent=4)
+
+
+    def update_peak_memory(self, peak_memory):
+        """
+        Update peak memory usage in session data if the new peak is higher.
+        """
+        data = self.get()
+        if "peak memory used by model(MiB)" in data:
+            stored_peak_memory = float(data["peak memory used by model(MiB)"])
+            if peak_memory > stored_peak_memory:
+                data["peak memory used by model(MiB)"] = f"{peak_memory:.5f}"
+        else:
+            data["peak memory used by model(MiB)"] = f"{peak_memory:.5f}"
+        with open(self.session_file, "w") as f:
+            json.dump(data, f, indent=4)
+            
     def close(self):
         self.logger.debug("Closing session {0}".format(self.session_file))
         if os.path.isfile(self.session_file):
             os.remove(self.session_file)
+

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -9,7 +9,6 @@ from ..default import EOS
 from .base import ErsiliaBase
 
 
-
 class Session(ErsiliaBase):
     def __init__(self, config_json):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
@@ -70,7 +69,6 @@ class Session(ErsiliaBase):
             self.logger.debug("No session exists")
             return None
 
-
     def update_total_memory(self, additional_memory):
         """
         Methods to get the the total memory of processess during serving and running.
@@ -83,7 +81,7 @@ class Session(ErsiliaBase):
         data["total memory used by model(MB)"] = f"{new_memory:.5f}"
         with open(self.session_file, "w") as f:
             json.dump(data, f, indent=4)
-    
+
     def update_cpu_time(self, cpu_time):
         """
         Methods to get the total cpu time of processess during serving and running
@@ -93,10 +91,9 @@ class Session(ErsiliaBase):
             data = {}
         current_cpu = float(data.get("CPU time used by model(seconds)", 0))
         new_cpu = current_cpu + cpu_time
-        data["CPU time used by model(seconds)"] = f"{new_cpu}"       
+        data["CPU time used by model(seconds)"] = f"{new_cpu}"
         with open(self.session_file, "w") as f:
             json.dump(data, f, indent=4)
-
 
     def update_peak_memory(self, peak_memory):
         """
@@ -111,9 +108,8 @@ class Session(ErsiliaBase):
             data["peak memory used by model(MiB)"] = f"{peak_memory:.5f}"
         with open(self.session_file, "w") as f:
             json.dump(data, f, indent=4)
-            
+
     def close(self):
         self.logger.debug("Closing session {0}".format(self.session_file))
         if os.path.isfile(self.session_file):
             os.remove(self.session_file)
-

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -23,6 +23,10 @@ from ..io.output_logger import TabularResultLogger
 from botocore.exceptions import ClientError, NoCredentialsError
 
 
+# Temporary path to log files until log files are fixed
+TEMP_FILE_LOGS = os.path.abspath("")
+
+
 def docker_stats(container_name=None):
     """
     This function will calculate the memory usage of the Docker container running Ersilia Models.
@@ -96,19 +100,17 @@ def log_files_metrics(file):
     misc_error_flag = False
     error_name = ""
     errors = {}
-    json_dict = {}
 
     try:
-        with open(file_log, "r") as file:
+        with open(file, "r") as file:
             line = None
             for line in file:
                 if not re.match(r"^\d{2}.\d{2}.\d{2} \| ", line):
+                    # continuation of log
                     if ersilia_error_flag:
+                        # catch the error name if hinted by previous line
                         error_name = line.rstrip()
-                        if error_name in errors:
-                            errors[error_name] += 1
-                        else:
-                            errors[error_name] = 1
+                        errors[error_name] += 1
                         ersilia_error_flag = False
                         continue
                     elif misc_error_flag:
@@ -120,12 +122,10 @@ def log_files_metrics(file):
                     # encountering new logs
                     # make sure error flags are closed
                     if ersilia_error_flag:
-                        errors["Unknown Ersilia exception class"] = (
-                            errors.get("Unknown Ersilia exception class", 0) + 1
-                        )
+                        errors["Unknown Ersilia exception class"] += 1
                         ersilia_error_flag = False
                     if misc_error_flag:
-                        errors[error_name] = errors.get(error_name, 0) + 1
+                        errors[error_name] += 1
                         misc_error_flag = False
                     if "| ERROR" in line:
                         error_count += 1
@@ -148,19 +148,15 @@ def log_files_metrics(file):
                 if misc_error_flag:
                     errors[error_name] += 1
 
-        json_dict = {}
-        json_dict["Error count"] = error_count
-
+        write_persistent_file(f"Error count: {error_count}", model_id)
         if len(errors) > 0:
-            json_dict["Breakdown by error types"] = {}
+            write_persistent_file(f"Breakdown by error types:", model_id)
             for error in errors:
-                json_dict["Breakdown by error types"][error] = errors[error]
-        json_dict["Warning count"] = warning_count
-        json_object = json.dumps(json_dict, indent=4)
-        write_persistent_file(json_object, model_id)
+                write_persistent_file(f"{error}: {errors[error]}", model_id)
+        write_persistent_file(f"Warning count: {warning_count}", model_id)
     except (IsADirectoryError, FileNotFoundError):
         logging.warning("Unable to calculate metrics for log file: log file not found")
-
+        
 
 def get_persistent_file_path(model_id):
     """
@@ -222,19 +218,17 @@ def close_persistent_file(model_id):
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
         log_files_metrics(TEMP_FILE_LOGS)
-
+        
         new_file_path = os.path.join(
             os.path.dirname(file_name),
             datetime.now().strftime("%Y-%m-%d_%H-%M-%S.txt"),
         )
         os.rename(file_name, new_file_path)
-
+        
     else:
-        raise FileNotFoundError(
-            f"The persistent file for model {model_id} does not exist. Cannot close file."
-        )
-
-
+        raise FileNotFoundError(f"The persistent file for model {model_id} does not exist. Cannot close file.")
+        
+        
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
     """Upload a file to an S3 bucket
 

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from .base import ErsiliaBase
 from collections import defaultdict
 from ..default import EOS, ERSILIA_RUNS_FOLDER
-from ..io.output_logger import TabularResultLogger 
+from ..io.output_logger import TabularResultLogger
 from botocore.exceptions import ClientError, NoCredentialsError
 
 
@@ -28,13 +28,12 @@ TEMP_FILE_LOGS = os.path.abspath("")
 
 
 def docker_stats(container_name=None):
-
     """
     This function will calculate the memory usage of the Docker container running Ersilia Models.
     it wil return a message if a container is not running.
     """
     try:
-        
+
         client = docker.from_env()
 
         if container_name:
@@ -48,35 +47,33 @@ def docker_stats(container_name=None):
         result = []
         for container in containers:
             stats = container.stats(stream=False)
-            mem_usage = stats['memory_stats']['usage'] / (1024 * 1024)
+            mem_usage = stats["memory_stats"]["usage"] / (1024 * 1024)
 
-            cpu_stats = stats['cpu_stats']
-            total_cpu_time = cpu_stats['cpu_usage']['total_usage'] / 1e9
-            
+            cpu_stats = stats["cpu_stats"]
+            total_cpu_time = cpu_stats["cpu_usage"]["total_usage"] / 1e9
+
             minutes = total_cpu_time // 60
             seconds = total_cpu_time % 60
-            
-            
+
             peak_memory = None
             # Get the peak memory usage recorded (if available)
-            if 'max_usage' in stats['memory_stats']:
-                peak_memory = stats['memory_stats']['max_usage'] / (1024 * 1024)
+            if "max_usage" in stats["memory_stats"]:
+                peak_memory = stats["memory_stats"]["max_usage"] / (1024 * 1024)
             else:
                 cgroup_path = f"/sys/fs/cgroup/system.slice/docker-{container.id}.scope/memory.peak"
             try:
-                with open(cgroup_path, 'r') as file:
+                with open(cgroup_path, "r") as file:
                     peak_memory = int(file.read().strip()) / (1024 * 1024)
             except FileNotFoundError:
                 print(f"cgroup file {cgroup_path} not found")
             except Exception as e:
                 print(f"An error occurred while reading cgroup file: {e}")
-                
-                
+
         return (
-                f"Total memory consumed by container '{container.name}': {mem_usage:.2f}MiB",
-                f"Total CPU time used by container '{container.name}': {int(minutes)} minutes {seconds:.2f} seconds",
-                f"Peak memory Used by container '{container.name}': {int(peak_memory)} MiB"
-                    )
+            f"Total memory consumed by container '{container.name}': {mem_usage:.2f}MiB",
+            f"Total CPU time used by container '{container.name}': {int(minutes)} minutes {seconds:.2f} seconds",
+            f"Peak memory Used by container '{container.name}': {int(peak_memory)} MiB",
+        )
 
     except docker.errors.NotFound:
         return [f"Error: Container '{container_name}' not found."]
@@ -161,32 +158,29 @@ def log_files_metrics(file):
         logging.warning("Unable to calculate metrics for log file: log file not found")
 
 
-
-
 def get_persistent_file_path(model_id):
     """
     Construct the persistent file path.
     :param model_id: The currently running model
     :return: The path to the persistent file
     """
-    return os.path.join(EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt")
-
+    return os.path.join(
+        EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt"
+    )
 
 
 def create_persistent_file(model_id):
-
     """
-    Create the persistent path file 
+    Create the persistent path file
     :param model_id: The currently running model
     """
 
     persistent_file_dir = os.path.dirname(get_persistent_file_path(model_id))
-    os.makedirs(persistent_file_dir, exist_ok=True)  
+    os.makedirs(persistent_file_dir, exist_ok=True)
     file_name = get_persistent_file_path(model_id)
-    
+
     with open(file_name, "w") as f:
         f.write("Session started for model: {0}\n".format(model_id))
-    
 
 
 def check_file_exists(model_id):
@@ -195,11 +189,10 @@ def check_file_exists(model_id):
     :param model_id: The currently running model
     :return: True if the file exists, False otherwise.
     """
-        
+
     return os.path.isfile(get_persistent_file_path(model_id))
-    
-       
-        
+
+
 def write_persistent_file(contents, model_id):
     """
     Writes contents to the current persistent file. Only writes if the file actually exists.
@@ -212,10 +205,11 @@ def write_persistent_file(contents, model_id):
             f.write(f"{contents}\n")
 
     else:
-        raise FileNotFoundError(f"The persistent file for model {model_id} does not exist. Cannot write contents.")
-        
+        raise FileNotFoundError(
+            f"The persistent file for model {model_id} does not exist. Cannot write contents."
+        )
 
-        
+
 def close_persistent_file(model_id):
     """
     Closes the persistent file, renaming it to a unique name.
@@ -224,16 +218,17 @@ def close_persistent_file(model_id):
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
         log_files_metrics(TEMP_FILE_LOGS)
-        
+
         new_file_path = os.path.join(
             os.path.dirname(file_name),
             datetime.now().strftime("%Y-%m-%d_%H-%M-%S.txt"),
         )
         os.rename(file_name, new_file_path)
-        
+
     else:
-        raise FileNotFoundError(f"The persistent file for model {model_id} does not exist. Cannot close file.")
-        
+        raise FileNotFoundError(
+            f"The persistent file for model {model_id} does not exist. Cannot close file."
+        )
 
 
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
@@ -336,7 +331,6 @@ def upload_to_cddvault(output_df, api_key):
         return False
 
 
-
 def read_csv(file_path):
     """
     Reads a CSV file and returns the data as a list of dictionaries.
@@ -344,45 +338,44 @@ def read_csv(file_path):
     :param file_path: Path to the CSV file.
     :return: A list of dictionaries containing the CSV data.
     """
-    with open(file_path, mode='r') as file:
+    with open(file_path, mode="r") as file:
         reader = csv.DictReader(file)
         data = [row for row in reader]
     return data
-    
-    
+
 
 def get_nan_counts(data_list):
-        """
-        Calculates the number of None values in each key of a list of dictionaries.
+    """
+    Calculates the number of None values in each key of a list of dictionaries.
 
-        :param data_list: List of dictionaries containing the data
-        :return: Dictionary containing the count of None values for each key
-        """
-        nan_count = {}
-    
-        # Collect all keys from data_list
-        all_keys = set(key for item in data_list for key in item.keys())
+    :param data_list: List of dictionaries containing the data
+    :return: Dictionary containing the count of None values for each key
+    """
+    nan_count = {}
 
-        # Initialize nan_count with all keys
-        for key in all_keys:
-            nan_count[key] = 0
+    # Collect all keys from data_list
+    all_keys = set(key for item in data_list for key in item.keys())
 
-        # Count None values for each key
-        for item in data_list:
-            for key, value in item.items():
-                if value is None:
-                    nan_count[key] += 1
+    # Initialize nan_count with all keys
+    for key in all_keys:
+        nan_count[key] = 0
 
-        return nan_count
-        
+    # Count None values for each key
+    for item in data_list:
+        for key, value in item.items():
+            if value is None:
+                nan_count[key] += 1
+
+    return nan_count
+
+
 class RunTracker(ErsiliaBase):
-
     """
     This class will be responsible for tracking model runs. It calculates the desired metadata based on a model's
     inputs, outputs, and other run-specific features, before uploading them to AWS to be ingested
     to Ersilia's Splunk dashboard.
     """
-    
+
     def __init__(self, model_id, config_json):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         self.time_start = None
@@ -392,16 +385,16 @@ class RunTracker(ErsiliaBase):
         # Initialize folders
         self.ersilia_runs_folder = os.path.join(EOS, ERSILIA_RUNS_FOLDER)
         os.makedirs(self.ersilia_runs_folder, exist_ok=True)
-        
+
         self.metadata_folder = os.path.join(self.ersilia_runs_folder, "metadata")
         os.makedirs(self.metadata_folder, exist_ok=True)
-        
+
         self.lake_folder = os.path.join(self.ersilia_runs_folder, "lake")
         os.makedirs(self.lake_folder, exist_ok=True)
-        
+
         self.logs_folder = os.path.join(self.ersilia_runs_folder, "logs")
         os.makedirs(self.logs_folder, exist_ok=True)
-        
+
         self.tabular_result_logger = TabularResultLogger()
 
 
@@ -422,7 +415,7 @@ class RunTracker(ErsiliaBase):
 #        for row in data:
 #            row.pop('key', None)
 #            row.pop('input', None)
-            
+
         # Convert data to a column-oriented format
 #        columns = defaultdict(list)
 #        for row in data:
@@ -444,8 +437,8 @@ class RunTracker(ErsiliaBase):
 #
 #            stats[column] = column_stats
 
+
 #        return stats
-        
         
     def get_file_sizes(self, input_file, output_file):
         """
@@ -468,8 +461,7 @@ class RunTracker(ErsiliaBase):
             "avg_input_size": input_avg_row_size,
             "avg_output_size": output_avg_row_size,
         }
-        
-        
+
     def check_types(self, result, metadata):
         """
         This method is responsible for checking the types of the output file against the expected types.
@@ -494,7 +486,9 @@ class RunTracker(ErsiliaBase):
 
         mismatched_types = 0
         for column, types in dtypes_list.items():
-            if not all(type_dict.get(dtype) == metadata["Output Type"][0] for dtype in types):
+            if not all(
+                type_dict.get(dtype) == metadata["Output Type"][0] for dtype in types
+            ):
                 mismatched_types += 1
 
         # Check if the shape is correct
@@ -509,22 +503,18 @@ class RunTracker(ErsiliaBase):
         logging.info("Output has", count, "mismatched types.\n")
 
         return {"mismatched_types": count, "correct_shape": correct_shape}
-        
-        
-        
+
     def get_peak_memory(self):
         """
-	Calculates the peak memory usage of ersilia's Python instance during the run.
-	:return: The peak memory usage in Megabytes.
-	"""
-	
+        Calculates the peak memory usage of ersilia's Python instance during the run.
+        :return: The peak memory usage in Megabytes.
+        """
+
         usage = resource.getrusage(resource.RUSAGE_SELF)
         peak_memory_kb = usage.ru_maxrss
-        peak_memory = peak_memory_kb / 1024 
+        peak_memory = peak_memory_kb / 1024
         return peak_memory
-        
 
- 
     def get_memory_info(self, process="ersilia"):
         """
         Retrieves the memory information of the current process
@@ -533,20 +523,26 @@ class RunTracker(ErsiliaBase):
             current_process = psutil.Process()
             process_name = current_process.name()
             cpu_times = current_process.cpu_times()
-        
+
             if process_name != process:
-                raise Exception(f"Unexpected process. Expected: {process}, but got: {process_name}")
-                     
-               
+                raise Exception(
+                    f"Unexpected process. Expected: {process}, but got: {process_name}"
+                )
+
             uss_mb = current_process.memory_full_info().uss / (1024 * 1024)
-            total_cpu_time = sum(cpu_time for cpu_time in (cpu_times.user, 
-                                                            cpu_times.system, 
-                                                            cpu_times.children_user,
-                                                            cpu_times.children_system, 
-                                                            cpu_times.iowait))
-            
+            total_cpu_time = sum(
+                cpu_time
+                for cpu_time in (
+                    cpu_times.user,
+                    cpu_times.system,
+                    cpu_times.children_user,
+                    cpu_times.children_system,
+                    cpu_times.iowait,
+                )
+            )
+
             return uss_mb, total_cpu_time
-            
+
         except psutil.NoSuchProcess:
             return "No such process found."
         except Exception as e:
@@ -583,8 +579,8 @@ class RunTracker(ErsiliaBase):
 
     def track(self, input, result, meta):
         """
-    	Tracks the results of a model run.
-    	"""
+        Tracks the results of a model run.
+        """
         self.time_start = datetime.now()
         json_dict = {}
         input_data = read_csv(input)
@@ -600,24 +596,23 @@ class RunTracker(ErsiliaBase):
         # checking for mismatched types
         nan_count = get_nan_counts(result_data)
         json_dict["nan_count"] = nan_count
-        
+
         json_dict["check_types"] = self.check_types(result_data, meta["metadata"])
 
         json_dict["file_sizes"] = self.get_file_sizes(input_data, result_data)
 
         json_dict["Docker Container"] = docker_stats()
 
-
         # Get the memory stats of the run processs
-        peak_memory = self.get_peak_memory()      
+        peak_memory = self.get_peak_memory()
         total_memory, cpu_time = self.get_memory_info()
-        
-        # Update the session file with the stats 
+
+        # Update the session file with the stats
         session.update_peak_memory(peak_memory)
         session.update_total_memory(total_memory)
         session.update_cpu_time(cpu_time)
         self.log_logs()
-        
+
         json_object = json.dumps(json_dict, indent=4)
         write_persistent_file(json_object, model_id)
         upload_to_s3(json_dict)

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -23,7 +23,6 @@ from ..io.output_logger import TabularResultLogger
 from botocore.exceptions import ClientError, NoCredentialsError
 
 
-
 def docker_stats(container_name=None):
     """
     This function will calculate the memory usage of the Docker container running Ersilia Models.
@@ -121,7 +120,9 @@ def log_files_metrics(file_log, model_id):
                     # encountering new logs
                     # make sure error flags are closed
                     if ersilia_error_flag:
-                        errors["Unknown Ersilia exception class"] = errors.get("Unknown Ersilia exception class", 0) + 1
+                        errors["Unknown Ersilia exception class"] = (
+                            errors.get("Unknown Ersilia exception class", 0) + 1
+                        )
                         ersilia_error_flag = False
                     if misc_error_flag:
                         errors[error_name] = errors.get(error_name, 0) + 1
@@ -146,15 +147,15 @@ def log_files_metrics(file_log, model_id):
                     errors["Unknown Ersilia exception class"] += 1
                 if misc_error_flag:
                     errors[error_name] += 1
-        
+
         json_dict = {}
         json_dict["Error count"] = error_count
-        
+
         if len(errors) > 0:
             json_dict["Breakdown by error types"] = {}
             for error in errors:
-                json_dict["Breakdown by error types"][error] = errors[error]      
-        json_dict["Warning count"] = warning_count      
+                json_dict["Breakdown by error types"][error] = errors[error]
+        json_dict["Warning count"] = warning_count
         json_object = json.dumps(json_dict, indent=4)
         write_persistent_file(json_object, model_id)
     except (IsADirectoryError, FileNotFoundError):
@@ -220,9 +221,7 @@ def close_persistent_file(model_id):
     """
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
-        file_log = os.path.join(
-        EOS,  "console.log"
-    )
+        file_log = os.path.join(EOS, "console.log")
         log_files_metrics(file_log, model_id)
 
         new_file_path = os.path.join(
@@ -235,9 +234,8 @@ def close_persistent_file(model_id):
         raise FileNotFoundError(
             f"The persistent file for model {model_id} does not exist. Cannot close file."
         )
-        
-        
-        
+
+
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
     """Upload a file to an S3 bucket
 
@@ -554,8 +552,6 @@ class RunTracker(ErsiliaBase):
             return "No such process found."
         except Exception as e:
             return str(e)
-            
-            
 
     def log_result(self, result):
         output_dir = os.path.join(self.lake_folder, self.model_id)
@@ -585,9 +581,7 @@ class RunTracker(ErsiliaBase):
         file_name = os.path.join(output_dir, "{0}.log".format(self.model_id))
         session_file = os.path.join(EOS, "session.json")
         shutil.copyfile(session_file, file_name)
-        
-        
-        
+
     def track(self, input, result, meta):
         """
         Tracks the results of a model run.

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -85,7 +85,7 @@ def docker_stats(container_name=None):
         return [f"An unexpected error occurred: {e}"]
 
 
-def log_files_metrics(file):
+def log_files_metrics(file, model_id):
     """
     This function will log the number of errors and warnings in the log files.
 
@@ -217,7 +217,7 @@ def close_persistent_file(model_id):
     """
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
-        log_files_metrics(TEMP_FILE_LOGS)
+        log_files_metrics(TEMP_FILE_LOGS, model_id)
 
         new_file_path = os.path.join(
             os.path.dirname(file_name),

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -23,9 +23,6 @@ from ..io.output_logger import TabularResultLogger
 from botocore.exceptions import ClientError, NoCredentialsError
 
 
-# Temporary path to log files until log files are fixed
-TEMP_FILE_LOGS = os.path.abspath("")
-
 
 def docker_stats(container_name=None):
     """
@@ -85,7 +82,7 @@ def docker_stats(container_name=None):
         return [f"An unexpected error occurred: {e}"]
 
 
-def log_files_metrics(file, model_id):
+def log_files_metrics(file_log, model_id):
     """
     This function will log the number of errors and warnings in the log files.
 
@@ -100,17 +97,19 @@ def log_files_metrics(file, model_id):
     misc_error_flag = False
     error_name = ""
     errors = {}
+    json_dict = {}
 
     try:
-        with open(file, "r") as file:
+        with open(file_log, "r") as file:
             line = None
             for line in file:
                 if not re.match(r"^\d{2}.\d{2}.\d{2} \| ", line):
-                    # continuation of log
                     if ersilia_error_flag:
-                        # catch the error name if hinted by previous line
                         error_name = line.rstrip()
-                        errors[error_name] += 1
+                        if error_name in errors:
+                            errors[error_name] += 1
+                        else:
+                            errors[error_name] = 1
                         ersilia_error_flag = False
                         continue
                     elif misc_error_flag:
@@ -122,10 +121,10 @@ def log_files_metrics(file, model_id):
                     # encountering new logs
                     # make sure error flags are closed
                     if ersilia_error_flag:
-                        errors["Unknown Ersilia exception class"] += 1
+                        errors["Unknown Ersilia exception class"] = errors.get("Unknown Ersilia exception class", 0) + 1
                         ersilia_error_flag = False
                     if misc_error_flag:
-                        errors[error_name] += 1
+                        errors[error_name] = errors.get(error_name, 0) + 1
                         misc_error_flag = False
                     if "| ERROR" in line:
                         error_count += 1
@@ -147,13 +146,17 @@ def log_files_metrics(file, model_id):
                     errors["Unknown Ersilia exception class"] += 1
                 if misc_error_flag:
                     errors[error_name] += 1
-
-        write_persistent_file(f"Error count: {error_count}", model_id)
+        
+        json_dict = {}
+        json_dict["Error count"] = error_count
+        
         if len(errors) > 0:
-            write_persistent_file(f"Breakdown by error types:", model_id)
+            json_dict["Breakdown by error types"] = {}
             for error in errors:
-                write_persistent_file(f"{error}: {errors[error]}", model_id)
-        write_persistent_file(f"Warning count: {warning_count}", model_id)
+                json_dict["Breakdown by error types"][error] = errors[error]      
+        json_dict["Warning count"] = warning_count      
+        json_object = json.dumps(json_dict, indent=4)
+        write_persistent_file(json_object, model_id)
     except (IsADirectoryError, FileNotFoundError):
         logging.warning("Unable to calculate metrics for log file: log file not found")
 
@@ -217,7 +220,10 @@ def close_persistent_file(model_id):
     """
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
-        log_files_metrics(TEMP_FILE_LOGS, model_id)
+        file_log = os.path.join(
+        EOS,  "console.log"
+    )
+        log_files_metrics(file_log, model_id)
 
         new_file_path = os.path.join(
             os.path.dirname(file_name),
@@ -229,8 +235,9 @@ def close_persistent_file(model_id):
         raise FileNotFoundError(
             f"The persistent file for model {model_id} does not exist. Cannot close file."
         )
-
-
+        
+        
+        
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
     """Upload a file to an S3 bucket
 
@@ -547,6 +554,8 @@ class RunTracker(ErsiliaBase):
             return "No such process found."
         except Exception as e:
             return str(e)
+            
+            
 
     def log_result(self, result):
         output_dir = os.path.join(self.lake_folder, self.model_id)
@@ -576,7 +585,9 @@ class RunTracker(ErsiliaBase):
         file_name = os.path.join(output_dir, "{0}.log".format(self.model_id))
         session_file = os.path.join(EOS, "session.json")
         shutil.copyfile(session_file, file_name)
-
+        
+        
+        
     def track(self, input, result, meta):
         """
         Tracks the results of a model run.

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -156,7 +156,7 @@ def log_files_metrics(file):
         write_persistent_file(f"Warning count: {warning_count}", model_id)
     except (IsADirectoryError, FileNotFoundError):
         logging.warning("Unable to calculate metrics for log file: log file not found")
-        
+
 
 def get_persistent_file_path(model_id):
     """
@@ -545,6 +545,8 @@ class RunTracker(ErsiliaBase):
             return "No such process found."
         except Exception as e:
             return str(e)
+            
+            
 
     def log_result(self, result):
         output_dir = os.path.join(self.lake_folder, self.model_id)
@@ -574,7 +576,9 @@ class RunTracker(ErsiliaBase):
         file_name = os.path.join(output_dir, "{0}.log".format(self.model_id))
         session_file = os.path.join(EOS, "session.json")
         shutil.copyfile(session_file, file_name)
-
+        
+        
+        
     def track(self, input, result, meta):
         """
         Tracks the results of a model run.

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -81,7 +81,7 @@ def docker_stats(container_name=None):
         return [f"An unexpected error occurred: {e}"]
 
 
-def log_files_metrics(file_log, model_id):
+def log_files_metrics(file):
     """
     This function will log the number of errors and warnings in the log files.
 
@@ -221,8 +221,7 @@ def close_persistent_file(model_id):
     """
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
-        file_log = os.path.join(EOS, "console.log")
-        log_files_metrics(file_log, model_id)
+        log_files_metrics(TEMP_FILE_LOGS)
 
         new_file_path = os.path.join(
             os.path.dirname(file_name),

--- a/ersilia/utils/docker.py
+++ b/ersilia/utils/docker.py
@@ -1,4 +1,5 @@
 import os
+import docker
 import subprocess
 from dockerfile_parse import DockerfileParser
 import tempfile
@@ -48,6 +49,7 @@ def is_udocker_installed():
 class SimpleDocker(object):
     def __init__(self, use_udocker=None):
         self.identifier = LongIdentifier()
+        self.client = docker.from_env()
         if use_udocker is None:
             self._with_udocker = self._use_udocker()
         else:
@@ -247,6 +249,125 @@ class SimpleDocker(object):
         name = self.run(org, img, tag, name=name)
         self.exec_container(name, cmd)
         self.kill(name)
+
+    def get_container(self):
+        """
+        This function will get the Docker container running Ersilia Models.
+        it wil return a message if a container is not running.
+        """
+
+        try:
+            containers = self.client.containers.list()
+
+            if not containers:
+                return ["No running containers found"]
+            return containers
+
+        except docker.errors.APIError as e:
+            return [f"Error: Docker API error: {e}"]
+        except KeyError as e:
+            return [f"KeyError: {e} in stats for container."]
+        except Exception as e:
+            return [f"An unexpected error occurred: {e}"]
+
+    def container_memory(self):
+        """
+        This function will get the total memory usage of the Docker container running Ersilia Models.
+        """
+
+        containers = self.get_container()
+        if isinstance(containers, list) and isinstance(containers[0], str):
+            return containers[0]
+
+        result = []
+        for container in containers:
+            stats = container.stats(stream=False)
+            mem_usage = stats["memory_stats"]["usage"] / (1024 * 1024)
+
+        return (
+            f"Total memory consumed by container '{container.name}': {mem_usage:.2f}MiB",
+        )
+
+    def container_cpu(self):
+        """
+        This function will get the CPU time of the Docker container running Ersilia Models.
+        """
+
+        containers = self.get_container()
+        if isinstance(containers, list) and isinstance(containers[0], str):
+            return containers[0]
+
+        for container in containers:
+            stats = container.stats(stream=False)
+            cpu_stats = stats["cpu_stats"]
+            total_cpu_time = cpu_stats["cpu_usage"]["total_usage"] / 1e9
+
+            minutes = total_cpu_time // 60
+            seconds = total_cpu_time % 60
+
+        return (
+            f"Total CPU time used by container '{container.name}': {int(minutes)} minutes {seconds:.2f} seconds",
+        )
+
+    def container_peak(self):
+        """
+        This function will get the peak memory of the Docker container running Ersilia Models.
+        """
+        try:
+            containers = self.get_container()
+            if isinstance(containers, list) and isinstance(containers[0], str):
+                return containers[0]
+
+            for container in containers:
+                stats = container.stats(stream=False)
+                peak_memory = None
+                if "memory_stats" in stats and "max_usage" in stats["memory_stats"]:
+                    peak_memory = stats["memory_stats"]["max_usage"] / (1024 * 1024)
+                    return peak_memory
+                if peak_memory is None:
+                    cgroup_path = None
+                    possible_paths = [
+                        f"/sys/fs/cgroup/system.slice/docker-{container.id}.scope/memory.peak",
+                        f"/sys/fs/cgroup/docker/{container.id}/memory.peak",
+                    ]
+                    for path in possible_paths:
+                        if os.path.exists(path):
+                            cgroup_path = path
+                            break
+
+                    if cgroup_path is None:
+                        print(
+                            f"Could not find cgroup file for container '{container.name}'"
+                        )
+                        continue
+                    try:
+                        with open(cgroup_path, "r") as file:
+                            peak_memory = int(file.read().strip()) / (1024 * 1024)
+                    except FileNotFoundError:
+                        print(f"cgroup file {cgroup_path} not found")
+                        continue
+                    except Exception as e:
+                        print(
+                            f"An error occurred while reading cgroup file {cgroup_path}: {e}"
+                        )
+                        continue
+            if peak_memory is not None:
+                return (
+                    f"Peak memory Used by container '{container.name}': {int(peak_memory)} MiB",
+                )
+
+            return (
+                f"Peak memory Used by container '{container.name}': {int(peak_memory)} MiB",
+            )
+        except docker.errors.NotFound as e:
+            print(f"Container {container.name} not found: {e}")
+            return None
+        except docker.errors.APIError as e:
+            print(f"Docker API error: {e}")
+            return None
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return None
 
 
 class SimpleDockerfileParser(DockerfileParser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ validators = [
     {version="~0.21.0", python=">=3.8"},
 ]
 
+psutil = ">=5.9.0"
 h5py = "^3.7.0" # For compatibility with isaura
 loguru = "^0.6.0" # For compatibility with isaura
 PyYAML = "^6.0.1"


### PR DESCRIPTION
**Description**

Rework code calculating memory usage - output and Docker container.

**Summary**

Ersilia model hub has different model server Implementations, each implementation handles specific deployment scenarios, such as local installation, conda environments, Docker containers, hosted services, etc. These implementations are defined in `Autoservice` class which makes use of the `service_class` objects to specify what service implementation to use for serving a model. By default, Ersilia models are fetched through Dockerhub and executed in a container. 

From this, we can split our model into two (2) groups.

- Models executed in a Docker Container.
- Models that do not utilize a Docker container.

The task here is to get three (3) key memory metrics from the underlying OS for these two (2) model types, for models that are executed in docker containers we will gather six (6) memory metrics.

- Total memory being used by the Docker container running the model.
- Peak memory used by the Docker container running the model
- CPU time used by the Docker container running the model.
- Total physical memory (ROM/RAM) being used at the serving and run level.
- Peak memory (ROM/RAM) being used at the serving and run level
- CPU time being used at the serving and run level.

For the second model type, we are only interested in the last three memory metrics listed above, to get these memory statistics, we made use of different libraries and APIs, specifically, Docker has a list of APIs for capturing such metrics, and apart from the key `max_usage` for getting the peak memory, which only works for a system with **cgroup V1** . To address this limitation, a solution has been included to access container memory data directly from the cgroup filesystem.

Also in the Ersilia process, after a model has been served through the model server, the memories are deallocated, so there is a need to update the memory information across different sessions(Serving, Getting predictions).   

 **USS** (unique set size) was used to get the total memory being used as opposed to **RSS** (resident set size), as it is the most representative metric for determining how much memory is being used by a process.

**Changes Made**

- Added  `docker_stats` method to get the different memory stats of  a docker, which will return a message if the process is not being executed in a container.
- Remove  `start_tracking` method as we are not utilizing tracemalloc.
- Modify `peak_memory`  method to get the peak memory usage of the process running the model.
- Added `get_memory_info` method that utilizes `psutil` to get the CPU time and the total memory used by the actual model.
- Added  `update_cpu_time` and `update_total_memory` functions in `session.py` to manage data accumulated across sessions. These functions continuously update CPU time and total memory values as they change during various sessions. Additionally, introduced `update_peak_memory` to track and compare peak memory values across sessions.
- Modify `serve` and `run` in `model.py` to reflect this changes and to ensure tracking and the various tracking directories are only being created when the track flags are used.

**Status**

- Various memory metrics tracked and gotten across a model Runtime. 

- The logging folder is only created and tracking is only done when a track flag is used.


Related to https://github.com/ersilia-os/ersilia/issues/1090 #1162 
