### PR TITLE
Track without output bug

### DIFF
--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from .base import ErsiliaBase
 from collections import defaultdict
 from ..default import EOS, ERSILIA_RUNS_FOLDER
-from ..utils.docker import SimpleDocker
 from ..io.output_logger import TabularResultLogger
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -111,17 +110,23 @@ def get_persistent_file_path(model_id):
     return os.path.join(
         EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt"
     )
+    return os.path.join(
+        EOS, ERSILIA_RUNS_FOLDER, "session", model_id, "current_session.txt"
+    )
 
 
 def create_persistent_file(model_id):
     """
+    Create the persistent path file
     Create the persistent path file
     :param model_id: The currently running model
     """
 
     persistent_file_dir = os.path.dirname(get_persistent_file_path(model_id))
     os.makedirs(persistent_file_dir, exist_ok=True)
+    os.makedirs(persistent_file_dir, exist_ok=True)
     file_name = get_persistent_file_path(model_id)
+
 
     with open(file_name, "w") as f:
         f.write("Session started for model: {0}\n".format(model_id))
@@ -134,7 +139,10 @@ def check_file_exists(model_id):
     :return: True if the file exists, False otherwise.
     """
 
+
     return os.path.isfile(get_persistent_file_path(model_id))
+
+
 
 
 def write_persistent_file(contents, model_id):
@@ -152,6 +160,10 @@ def write_persistent_file(contents, model_id):
         raise FileNotFoundError(
             f"The persistent file for model {model_id} does not exist. Cannot write contents."
         )
+        raise FileNotFoundError(
+            f"The persistent file for model {model_id} does not exist. Cannot write contents."
+        )
+
 
 
 def close_persistent_file(model_id):
@@ -161,22 +173,19 @@ def close_persistent_file(model_id):
     """
     if check_file_exists(model_id):
         file_name = get_persistent_file_path(model_id)
-        file_log = os.path.join(
-        EOS,  "console.log"
-    )
-        log_files_metrics(file_log, model_id)
+        log_files_metrics(TEMP_FILE_LOGS)
+
         new_file_path = os.path.join(
             os.path.dirname(file_name),
             datetime.now().strftime("%Y-%m-%d_%H-%M-%S.txt"),
         )
         os.rename(file_name, new_file_path)
-        
+
     else:
-    
         raise FileNotFoundError(
             f"The persistent file for model {model_id} does not exist. Cannot close file."
         )
-        
+
 
 def upload_to_s3(json_dict, bucket="ersilia-tracking", object_name=None):
     """Upload a file to an S3 bucket
@@ -285,16 +294,32 @@ def read_csv(file_path):
     :param file_path: Path to the CSV file.
     :return: A list of dictionaries containing the CSV data.
     """
-    with open(file_path, mode="r") as file:
+
+    with open("output.csv", "w", newline="") as csvfile:
+        csvWriter = csv.writer(csvfile)
+        for row in file_path:
+            csvWriter.writerow(row)
+
+    with open("output.csv", mode="r") as file:
         reader = csv.DictReader(file)
         data = [row for row in reader]
     return data
 
 
+
 def get_nan_counts(data_list):
     """
     Calculates the number of None values in each key of a list of dictionaries.
+    """
+    Calculates the number of None values in each key of a list of dictionaries.
 
+    :param data_list: List of dictionaries containing the data
+    :return: Dictionary containing the count of None values for each key
+    """
+    nan_count = {}
+
+    # Collect all keys from data_list
+    all_keys = set(key for item in data_list for key in item.keys())
     :param data_list: List of dictionaries containing the data
     :return: Dictionary containing the count of None values for each key
     """
@@ -306,12 +331,23 @@ def get_nan_counts(data_list):
     # Initialize nan_count with all keys
     for key in all_keys:
         nan_count[key] = 0
+    # Initialize nan_count with all keys
+    for key in all_keys:
+        nan_count[key] = 0
 
     # Count None values for each key
     for item in data_list:
         for key, value in item.items():
             if value is None:
                 nan_count[key] += 1
+    # Count None values for each key
+    for item in data_list:
+        for key, value in item.items():
+            if value is None:
+                nan_count[key] += 1
+
+    return nan_count
+
 
     return nan_count
 
@@ -323,6 +359,7 @@ class RunTracker(ErsiliaBase):
     to Ersilia's Splunk dashboard.
     """
 
+
     def __init__(self, model_id, config_json):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         self.time_start = None
@@ -333,60 +370,73 @@ class RunTracker(ErsiliaBase):
         self.ersilia_runs_folder = os.path.join(EOS, ERSILIA_RUNS_FOLDER)
         os.makedirs(self.ersilia_runs_folder, exist_ok=True)
 
+
         self.metadata_folder = os.path.join(self.ersilia_runs_folder, "metadata")
         os.makedirs(self.metadata_folder, exist_ok=True)
+
 
         self.lake_folder = os.path.join(self.ersilia_runs_folder, "lake")
         os.makedirs(self.lake_folder, exist_ok=True)
 
+
         self.logs_folder = os.path.join(self.ersilia_runs_folder, "logs")
         os.makedirs(self.logs_folder, exist_ok=True)
 
+
         self.tabular_result_logger = TabularResultLogger()
 
+    def start_tracking(self):
+        """
+        Runs any code necessary for the beginning of the run.
+        Currently necessary for tracking the runtime and memory usage of a run.
 
-#    TODO: see the following link for more details
-#    https://github.com/ersilia-os/ersilia/issues/1165?notification_referrer_id=NT_kwDOAsB0trQxMTEyNTc5MDIxNzo0NjE2NzIyMg#issuecomment-2178596998
-    
-#    def stats(self, result):
-#        """
-#        Stats function: calculates the basic statistics of the output file from a model. This includes the
-#        mode (if applicable), minimum, maximum, and standard deviation.
-#        :param result: The path to the model's output file.
-#        :return: A dictionary containing the stats for each column of the result.
-#        """
+        """
+        self.time_start = datetime.now()
+        tracemalloc.start()
+        self.memory_usage_start = tracemalloc.get_traced_memory()[0]
 
-#        data = read_csv(result)
+    #    TODO: see the following link for more details
+    #    https://github.com/ersilia-os/ersilia/issues/1165?notification_referrer_id=NT_kwDOAsB0trQxMTEyNTc5MDIxNzo0NjE2NzIyMg#issuecomment-2178596998
 
-        # drop first two columns (key, input)
-#        for row in data:
-#            row.pop('key', None)
-#            row.pop('input', None)
+    #    def stats(self, result):
+    #        """
+    #        Stats function: calculates the basic statistics of the output file from a model. This includes the
+    #        mode (if applicable), minimum, maximum, and standard deviation.
 
-        # Convert data to a column-oriented format
-#        columns = defaultdict(list)
-#        for row in data:
-#            for key, value in row.items():
-#                columns[key].append(float(value))
+    #        :param result: The path to the model's output file.
+    #        :return: A dictionary containing the stats for each column of the result.
+    #        """
 
-        # Calculate statistics
-#        stats = {}
-#        for column, values in columns.items():
-#            column_stats = {}
-#            column_stats["mean"] = statistics.mean(values)
-#            try:
-#                column_stats["mode"] = statistics.mode(values)
-#            except statistics.StatisticsError:
-#                column_stats["mode"] = None
-#            column_stats["min"] = min(values)
-#            column_stats["max"] = max(values)
-#            column_stats["std"] = statistics.stdev(values) if len(values) > 1 else 0
-#
-#            stats[column] = column_stats
+    #        data = read_csv(result)
 
+    # drop first two columns (key, input)
+    #        for row in data:
+    #            row.pop('key', None)
+    #            row.pop('input', None)
 
-#        return stats
-        
+    # Convert data to a column-oriented format
+    #        columns = defaultdict(list)
+    #        for row in data:
+    #            for key, value in row.items():
+    #                columns[key].append(float(value))
+
+    # Calculate statistics
+    #        stats = {}
+    #        for column, values in columns.items():
+    #            column_stats = {}
+    #            column_stats["mean"] = statistics.mean(values)
+    #            try:
+    #                column_stats["mode"] = statistics.mode(values)
+    #            except statistics.StatisticsError:
+    #                column_stats["mode"] = None
+    #            column_stats["min"] = min(values)
+    #            column_stats["max"] = max(values)
+    #            column_stats["std"] = statistics.stdev(values) if len(values) > 1 else 0
+    #
+    #            stats[column] = column_stats
+
+    #        return stats
+
     def get_file_sizes(self, input_file, output_file):
         """
         Calculates the size of the input and output dataframes, as well as the average size of each row.
@@ -408,6 +458,7 @@ class RunTracker(ErsiliaBase):
             "avg_input_size": input_avg_row_size,
             "avg_output_size": output_avg_row_size,
         }
+
 
     def check_types(self, result, metadata):
         """
@@ -436,6 +487,9 @@ class RunTracker(ErsiliaBase):
             if not all(
                 type_dict.get(dtype) == metadata["Output Type"][0] for dtype in types
             ):
+            if not all(
+                type_dict.get(dtype) == metadata["Output Type"][0] for dtype in types
+            ):
                 mismatched_types += 1
 
         # Check if the shape is correct
@@ -451,52 +505,16 @@ class RunTracker(ErsiliaBase):
 
         return {"mismatched_types": count, "correct_shape": correct_shape}
 
+
     def get_peak_memory(self):
         """
         Calculates the peak memory usage of ersilia's Python instance during the run.
-        :return: The peak memory usage in Megabytes.
+        :return: The peak memory usage in bytes.
         """
-
-        usage = resource.getrusage(resource.RUSAGE_SELF)
-        peak_memory_kb = usage.ru_maxrss
-        peak_memory = peak_memory_kb / 1024
+        peak_memory = tracemalloc.get_traced_memory()[1] - self.memory_usage_start
+        tracemalloc.stop()
         return peak_memory
 
-
-    def get_memory_info(self, process="ersilia"):
-        """
-        Retrieves the memory information of the current process
-        """
-        try:
-            current_process = psutil.Process()
-            process_name = current_process.name()
-            cpu_times = current_process.cpu_times()
-
-            if process_name != process:
-                raise Exception(
-                    f"Unexpected process. Expected: {process}, but got: {process_name}"
-                )
-
-            uss_mb = current_process.memory_full_info().uss / (1024 * 1024)
-            total_cpu_time = sum(
-                cpu_time
-                for cpu_time in (
-                    cpu_times.user,
-                    cpu_times.system,
-                    cpu_times.children_user,
-                    cpu_times.children_system,
-                    cpu_times.iowait,
-                )
-            )
-
-            return uss_mb, total_cpu_time
-
-        except psutil.NoSuchProcess:
-            return "No such process found."
-        except Exception as e:
-            return str(e)
-            
-            
     def log_result(self, result):
         output_dir = os.path.join(self.lake_folder, self.model_id)
         if not os.path.exists(output_dir):
@@ -532,8 +550,7 @@ class RunTracker(ErsiliaBase):
         """
         Tracks the results of a model run.
         """
-        self.time_start = datetime.now()
-        self.docker_client = SimpleDocker()
+        self.start_tracking()
         json_dict = {}
         input_data = read_csv(input)
         result_data = read_csv(result)
@@ -549,27 +566,12 @@ class RunTracker(ErsiliaBase):
         nan_count = get_nan_counts(result_data)
         json_dict["nan_count"] = nan_count
 
+
         json_dict["check_types"] = self.check_types(result_data, meta["metadata"])
 
         json_dict["file_sizes"] = self.get_file_sizes(input_data, result_data)
-   
-        docker_info = (self.docker_client.container_memory(), 
-        self.docker_client.container_cpu(), 
-        self.docker_client.container_peak()
-        )
-        
-        
-        json_dict["Docker Container"] = docker_info
 
-        # Get the memory stats of the run processs
-        peak_memory = self.get_peak_memory()
-        total_memory, cpu_time = self.get_memory_info()
-
-        # Update the session file with the stats
-        session.update_peak_memory(peak_memory)
-        session.update_total_memory(total_memory)
-        session.update_cpu_time(cpu_time)
-        self.log_logs()
+        json_dict["peak_memory_use"] = self.get_peak_memory()
 
         json_object = json.dumps(json_dict, indent=4)
         write_persistent_file(json_object, model_id)


### PR DESCRIPTION
**Description**
If track flag is used without specifying an output, an error is returned. This is because tracking requires a result parameter, which is the output of a run session. The error is thrown because the output being passed from run into the parameter is a generator object and not a csv file.

**Changes Made**
Wrote the generator file into a csv file, which is now read into the track function.

**Status**
Tracing now works without specifying output

**To do**
Make sure track flag works with all output formats (csv, tsv, json and h5) supported by ersilia 




Related to #1131 
Closes #1164 