### PR TITLE
Added the service class method to the modelcard

### DIFF
--- a/ersilia/hub/content/card.py
+++ b/ersilia/hub/content/card.py
@@ -45,7 +45,7 @@ try:
 except:
     Hdf5Explorer = None
 
-from ...default import CARD_FILE, METADATA_JSON_FILE
+from ...default import CARD_FILE, METADATA_JSON_FILE, SERVICE_CLASS_FILE
 
 
 class BaseInformation(ErsiliaBase):
@@ -714,7 +714,18 @@ class LocalCard(ErsiliaBase):
             return card
         else:
             return None
-
+            
+    def get_service_class(self, model_id):
+        service_class_path = os.path.join(
+                self._get_bundle_location(model_id), SERVICE_CLASS_FILE
+            )
+        
+        if os.path.exists(service_class_path):
+            with open(service_class_path, "r") as f:
+                service_class = f.read().strip()
+            return service_class
+        else:
+            return None
 
 class LakeCard(ErsiliaBase):
     def __init__(self, config_json=None):
@@ -760,3 +771,10 @@ class ModelCard(object):
             return json.dumps(card, indent=4)
         else:
             return card
+     
+    def service_class(self, model_id, as_json=False):
+        service = self.lc.get_service_class(model_id)
+        if service is None:
+            return
+        else:
+            return service

--- a/ersilia/hub/content/card.py
+++ b/ersilia/hub/content/card.py
@@ -716,6 +716,11 @@ class LocalCard(ErsiliaBase):
             return None
             
     def get_service_class(self, model_id):
+        """
+        This method returns information about how the model was fetched by reading 
+        the service class file located in the model's bundle directory. If the service 
+        class file does not exist, it returns None.
+        """
         service_class_path = os.path.join(
                 self._get_bundle_location(model_id), SERVICE_CLASS_FILE
             )
@@ -772,7 +777,7 @@ class ModelCard(object):
         else:
             return card
      
-    def service_class(self, model_id, as_json=False):
+    def get_service_class(self, model_id, as_json=False):
         service = self.lc.get_service_class(model_id)
         if service is None:
             return

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -197,7 +197,7 @@ class ModelCatalog(ErsiliaBase):
                 status = self._get_status(card)
                 inputs = self._get_input(card)
                 output = self._get_output(card)
-                service_class = mc.service_class(model_id)
+                service_class = mc.get_service_class(model_id)
                 R += [[model_id, slug, title, status, inputs, output, service_class]]
             columns = ["Identifier", "Slug", "Title", "Status", "Input", "Output", "Service Class"]
         logger.info("Found {0} models".format(len(R)))

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -87,6 +87,27 @@ class ModelCatalog(ErsiliaBase):
             return card["Slug"]
         return None
 
+    def _get_status(self, card):
+        if "status" in card:
+            return card["status"]
+        if "Status" in card:
+            return card["Status"]
+        return None
+    
+    def _get_input(self, card):
+        if "input" in card:
+            return card["input"][0]
+        if "Input" in card:
+            return card["Input"][0]
+        return None
+        
+    def _get_output(self, card):
+        if "output" in card:
+            return card["output"][0]
+        if "Output" in card:
+            return card["Output"][0]
+        return None
+                
     def airtable(self):
         """List models available in AirTable Ersilia Model Hub base"""
         if webbrowser:
@@ -173,8 +194,12 @@ class ModelCatalog(ErsiliaBase):
                 card = mc.get(model_id)
                 slug = self._get_slug(card)
                 title = self._get_title(card)
-                R += [[model_id, slug, title]]
-            columns = ["Identifier", "Slug", "Title"]
+                status = self._get_status(card)
+                inputs = self._get_input(card)
+                output = self._get_output(card)
+                service_class = mc.service_class(model_id)
+                R += [[model_id, slug, title, status, inputs, output, service_class]]
+            columns = ["Identifier", "Slug", "Title", "Status", "Input", "Output", "Service Class"]
         logger.info("Found {0} models".format(len(R)))
         if len(R) == 0:
             return None


### PR DESCRIPTION
Related to this (comment)[https://github.com/ersilia-os/ersilia/issues/1072#issuecomment-2185852513]

**Description**

Make `ersilia catalog --local --more` verbose in its output including information about how the model was fetched.

**Changes made**

- Added `get_service_class` method to the `Localcard` class in `card.py`.
- Added `service_class` method to the `Modelcard`.
- Added a series of private method to get the status, input and output type of a model in `catalog.py`.
- Modified  Local to display this new additional information.

**Status**

- Old model local catalog output  

```JSON
[
    {
        "Identifier": "eos4wt0",
        "Slug": "morgan-fps",
        "Title": "Morgan Fingerprints"
    },
    {
        "Identifier": "eos30f3",
        "Slug": "dmpnn-herg",
        "Title": "Prediction of hERG Channel Blockers with Directed Message Passing Neural Networks"
    },
    {
        "Identifier": "eos4se9",
        "Slug": "smiles2iupac",
        "Title": "STOUT: SMILES to IUPAC name translator"
    },
    {
        "Identifier": "eos3b5e",
        "Slug": "molecular-weight",
        "Title": "Molecular weight"
    }
]
```

- New model local catalog output 

```JSON
[
    {
        "Identifier": "eos4wt0",
        "Slug": "morgan-fps",
        "Title": "Morgan Fingerprints",
        "Status": "Ready",
        "Input": "Compound",
        "Output": "Descriptor",
        "Service Class": "pulled_docker"
    },
    {
        "Identifier": "eos30f3",
        "Slug": "dmpnn-herg",
        "Title": "Prediction of hERG Channel Blockers with Directed Message Passing Neural Networks",
        "Status": "Ready",
        "Input": "Compound",
        "Output": "Score",
        "Service Class": "pulled_docker"
    },
    {
        "Identifier": "eos4se9",
        "Slug": "smiles2iupac",
        "Title": "STOUT: SMILES to IUPAC name translator",
        "Status": "Ready",
        "Input": "Compound",
        "Output": "Text",
        "Service Class": "pulled_docker"
    },
    {
        "Identifier": "eos3b5e",
        "Slug": "molecular-weight",
        "Title": "Molecular weight",
        "Status": "Ready",
        "Input": "Compound",
        "Output": "Other value",
        "Service Class": "pulled_docker"
    }
]
```


Related to #1072