### PR TITLE
Ersilia Catalog Bug when no models are available

### DIFF
--- a/ersilia/cli/commands/catalog.py
+++ b/ersilia/cli/commands/catalog.py
@@ -1,6 +1,7 @@
 import click
 
 from . import ersilia_cli
+from .. import echo
 from ...hub.content.catalog import ModelCatalog
 from ...hub.content.search import ModelSearcher
 
@@ -32,7 +33,8 @@ def catalog_cmd():
     def catalog(local=False, file_name=None, browser=False, more=False):
         if local is True and browser is True:
             click.echo(
-                "You cannot show the local model catalog in the browser", fg="red"
+                "You cannot show the local model catalog in the browser",
+                fg="red",
             )
         if more:
             only_identifier = False
@@ -43,15 +45,25 @@ def catalog_cmd():
             mc.airtable()
             return
         if local:
+            catalog_table = mc.local()
+            if not catalog_table.data:
+                click.echo(
+                    click.style(
+                        "No local model is available. Please fetch a model by running 'ersilia fetch ...'",
+                        fg="red",
+                    )
+                )
+                return
             if file_name is None:
-                catalog = mc.local().as_json()
+                catalog = catalog_table.as_json()
             else:
-                mc.local().write(file_name)
+                catalog_table.write(file_name)
                 catalog = None
         else:
+            catalog_table = mc.hub()
             if file_name is None:
-                catalog = mc.hub().as_json()
+                catalog = catalog_table.as_json()
             else:
-                mc.hub().write(file_name)
+                catalog_table.write(file_name)
                 catalog = None
         click.echo(catalog)

--- a/ersilia/cli/commands/catalog.py
+++ b/ersilia/cli/commands/catalog.py
@@ -1,7 +1,6 @@
 import click
 
 from . import ersilia_cli
-from .. import echo
 from ...hub.content.catalog import ModelCatalog
 from ...hub.content.search import ModelSearcher
 
@@ -44,26 +43,19 @@ def catalog_cmd():
         if browser:
             mc.airtable()
             return
-        if local:
-            catalog_table = mc.local()
-            if not catalog_table.data:
-                click.echo(
-                    click.style(
-                        "No local model is available. Please fetch a model by running 'ersilia fetch ...'",
-                        fg="red",
-                    )
+        catalog_table = mc.local() if local else mc.hub()
+        if local and not catalog_table.data:
+            click.echo(
+                click.style(
+                    "No local model is available. Please fetch a model by running 'ersilia fetch ...'",
+                    fg="red",
                 )
-                return
-            if file_name is None:
-                catalog = catalog_table.as_json()
-            else:
-                catalog_table.write(file_name)
-                catalog = None
+            )
+            return
+        if file_name is None:
+            catalog = catalog_table.as_json()
         else:
-            catalog_table = mc.hub()
-            if file_name is None:
-                catalog = catalog_table.as_json()
-            else:
-                catalog_table.write(file_name)
-                catalog = None
+            catalog_table.write(file_name)
+            catalog = None
+
         click.echo(catalog)

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -30,7 +30,7 @@ class Session(ErsiliaBase):
 
     def current_service_class(self):
         data = self.get()
-        if data is None:
+        if data is None or data.get("service_class") is None:
             return None
         else:
             return data["service_class"]

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -177,7 +177,7 @@ class ModelCatalog(ErsiliaBase):
             columns = ["Identifier", "Slug", "Title"]
         logger.info("Found {0} models".format(len(R)))
         if len(R) == 0:
-            return None
+            return CatalogTable(data=[], columns=columns)
         return CatalogTable(data=R, columns=columns)
 
     def bentoml(self):


### PR DESCRIPTION
**Description**
When you try to run ersilia catalog --local but no models are available locally, instead of telling you there is no local model available, it outputs an error:

**Changes Made**
-updated the `local` method to return an empty `catalogue_table` if no models are found.
-updated the `catalogue` command to print a message when the `catalogue_table` has no data

**Status**
"No local model is available. Please fetch a model by running 'ersilia fetch ...'" is returned when you run  `ersilia catalog --local` and no local model is available 




Related to #1072 