### PR TITLE
Modified the time tracking method to accurately track time taken

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -42,8 +42,6 @@ def run_cmd():
             )
             return
         
-        start_time = time.time()
-        
         mdl = ErsiliaModel(
             model_id,
             service_class=service_class,

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -1,11 +1,13 @@
 import click
 import json
 import types
+import time
 
 from . import ersilia_cli
 from .. import echo
 from ... import ErsiliaModel
 from ...core.session import Session
+from ...core.tracking import RunTracker
 
 
 def run_cmd():
@@ -27,6 +29,7 @@ def run_cmd():
         help="Assume that the run is standard and, therefore, do not do so many checks.",
     )
     def run(input, output, batch_size, standard):
+        start_time = time.time()
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
@@ -38,7 +41,9 @@ def run_cmd():
                 fg="red",
             )
             return
-
+        
+        start_time = time.time()
+        
         mdl = ErsiliaModel(
             model_id,
             service_class=service_class,
@@ -61,3 +66,17 @@ def run_cmd():
                     echo("Something went wrong", fg="red")
         else:
             echo(result)
+            
+        if track_runs:
+            """
+            Retrieve the time taken to run the model and update the total. 
+            """
+            time_tracker = RunTracker(
+            model_id=model_id,
+            config_json=None
+            )
+            
+            time_tracker.update_total_time(
+            model_id=model_id,
+            start_time=start_time
+            )      

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -1,9 +1,11 @@
 import click
+import time
 
 from .. import echo
 from . import ersilia_cli
 from ... import ErsiliaModel
 from ..messages import ModelNotFound
+from ...core.tracking import write_persistent_file
 
 
 def serve_cmd():
@@ -31,6 +33,7 @@ def serve_cmd():
         default=False,
     )
     def serve(model, lake, docker, port, track):
+        start_time = time.time()
         if docker:
             service_class = "docker"
         else:
@@ -44,6 +47,8 @@ def serve_cmd():
         )
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
+            
+        
         mdl.serve()
         if mdl.url is None:
             echo("No URL found. Service unsuccessful.", fg="red")
@@ -68,3 +73,12 @@ def serve_cmd():
         echo("")
         echo(":person_tipping_hand: Information:", fg="blue")
         echo("   - info", fg="blue")
+        
+        if track:
+            """
+            Retrieve the time taken in seconds to serve the Model.
+            """
+            end_time = time.time()
+            duration = end_time - start_time
+            content = "Total time taken: {0}\n".format(duration)
+            write_persistent_file(content, mdl.model_id)


### PR DESCRIPTION
**Description**

The time tracking method in use does not accurately depicts the time taken in a model run

**Changes made**

- Introduce an `update_total_time` method in `tracking.py` to get an accurate measure of time across the two (2) process, minus the time spent waiting for user input(for the CLI).
- Track time in `serve.py`.
- Track time in `run.py`.

**Status**

- A time value that reflects and depicts the total time taken for our model to run.

Related to #1090 