### PR TITLE
Remove annoying debug logs

### DIFF
--- a/ersilia/hub/delete/delete.py
+++ b/ersilia/hub/delete/delete.py
@@ -125,7 +125,6 @@ class ModelBentoDeleter(ErsiliaBase):
         ml = ModelCatalog()
         try:
             catalog = ml.bentoml()
-            self.logger.debug(catalog)
         except:
             self.logger.debug("No BentoML Catalog available")
             catalog = None


### PR DESCRIPTION
**Description**

During a GitHub Actions workflow or when fetching on a system without BentoML installed, BentoML is automatically installed using the command `git clone --filter=blob:none --quiet https://github.com/ersilia-os/bentoml-ersilia.git /tmp/pip-req-build-4zsvpc12` , BentoML services are then listed and saved in a catalog, a debug method was used to output this catalog before the services apart from the latest one are deleted during fetching.


**Changes made**

- Debug statement deleted.

**Status**

Code does not appear in git action anymore.

Closes #1080  