### PR TITLE
Refactor tracking to support a single SMILES string input

### DIFF
--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -496,13 +496,13 @@ class ErsiliaModel(ErsiliaBase):
             result = self._run(
                 input=input, output=output, batch_size=batch_size, track_run=track_run
             )
-            # Start tracking model run if track flag is used in serve
-            if self._run_tracker is not None and track_run:
-                self._run_tracker.track(
-                    input=input, result=result, meta=self._model_info
-                )
-                self._run_tracker.log(result=result, meta=self._model_info)
-            return result
+        # Start tracking model run if track flag is used in serve
+        if self._run_tracker is not None and track_run:
+            self._run_tracker.track(
+                input=input, result=result, meta=self._model_info
+            )
+            self._run_tracker.log(result=result, meta=self._model_info)
+        return result
 
     @property
     def paths(self):

--- a/ersilia/utils/csvfile.py
+++ b/ersilia/utils/csvfile.py
@@ -1,4 +1,6 @@
+import os
 import csv
+import json
 
 
 class CsvDataLoader(object):
@@ -21,3 +23,33 @@ class CsvDataLoader(object):
                 self.keys += [r[0]]
                 self.inputs += [r[1]]
                 self.values += [r[-len(self.features) :]]
+                
+                
+  
+    def _read_csv_tsv(self, file_path, delimiter):
+        with open(file_path, mode='r') as file:
+            reader = csv.DictReader(file, delimiter=delimiter)
+            data = [row for row in reader]
+            return data
+
+    def _read_json(self, file_path):
+        with open(file_path, mode="r") as file:
+            return json.load(file)
+
+
+    def read(self, file_path):
+        """
+        Reads a file and returns the data as a list of dictionaries.
+
+        :param file_path: Path to the CSV file.
+        :return: A list of dictionaries containing the CSV data.
+        """
+       
+        file_extension = os.path.splitext(file_path)[1].lower()
+        if file_extension == '.json':
+            return self._read_json(file_path)
+        elif file_extension in ['.csv', '.tsv']:
+            delimiter = '\t' if file_extension == '.tsv' else ','
+            return self._read_csv_tsv(file_path, delimiter)
+        else:
+            raise ValueError("Unsupported file format")


### PR DESCRIPTION
**Description**

Making tracking work when input is just a single SMILE string.

**Changes Made**

- Modified and moved `read_csv` method to `utils/csv`, and created a dictionary method to process generator output before storing to a CSV file.
- A minor fix in `model.py` to enable tracking if `standard run` was enabled.

**Status**
Tracking works with different input/output formats.

Related to #1170
 
