### PR TITLE
Specify repo_path while fetching the dummy model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Fetch model
           command: |
               source activate ersilia
-              ersilia -v fetch eos0t01
+              ersilia -v fetch eos0t01 --repo_path ./test/models/eos0t01
       - run:
           name: Delete model
           command: |


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [ ] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

**Description**

CircleCI test seems to be failing with the new feature that integrates ersilia-pack/fastapi into ersilia. This is possibly because with this change, now ersilia CLI cannot easily fetch models that on your system without repo-path which is required to decided which way to "pack" the model (ie with bentoml or ersilia pack)

**Changes to be made**

Specify repo_path flag in ersilia fetch command in the CI test config.

**Status**
Done, to run the test in CI