### PR TITLE
Getting model source value

### DIFF
--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -113,6 +113,7 @@ def fetch_cmd():
             force_with_bentoml=with_bentoml,
             force_with_fastapi=with_fastapi,
             hosted_url=from_url,
+            local_dir=from_dir,
         )
         _fetch(mf, model_id)
         echo(":thumbs_up: Model {0} fetched successfully!".format(model_id), fg="green")

--- a/ersilia/default.py
+++ b/ersilia/default.py
@@ -48,6 +48,7 @@ PREDEFINED_EXAMPLE_FILES = [
 DEFAULT_ERSILIA_ERROR_EXIT_CODE = 1
 METADATA_JSON_FILE = "metadata.json"
 SERVICE_CLASS_FILE = "service_class.txt"
+MODEL_SOURCE_FILE = "model_source.txt"
 APIS_LIST_FILE = "apis_list.txt"
 INFORMATION_FILE = "information.json"
 IS_FETCHED_FROM_DOCKERHUB_FILE = "from_dockerhub.json"

--- a/ersilia/hub/content/information.py
+++ b/ersilia/hub/content/information.py
@@ -16,6 +16,8 @@ from ...default import (
     CARD_FILE,
     SERVICE_CLASS_FILE,
     APIS_LIST_FILE,
+    EOS,
+    MODEL_SOURCE_FILE,
 )
 
 
@@ -44,6 +46,14 @@ class Information(ErsiliaBase):
         else:
             return None
 
+    def _get_model_source(self):
+        model_source_file = os.path.join(EOS, MODEL_SOURCE_FILE)
+        if os.path.exists(model_source_file):
+            with open(model_source_file) as f:
+                return f.read().rstrip()
+        else:
+            return None
+        
     def _get_api_schema(self):
         api_schema_file = os.path.join(self.dest_folder, API_SCHEMA_FILE)
         if os.path.exists(api_schema_file):
@@ -88,6 +98,7 @@ class Information(ErsiliaBase):
         data = {
             "pack_mode": self._get_pack_mode(),
             "service_class": self._get_service_class(),
+            "model_source": self._get_model_source(),
             "apis_list": self._get_apis_list(),
             "api_schema": self._get_api_schema(),
             "size": self._get_size(),
@@ -171,3 +182,4 @@ class InformationDisplayer(ErsiliaBase):
         self._docker_info()
         text = "For more information, please visit https://ersilia.io/model-hub"
         self._echo(text, fg="black")
+

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -231,15 +231,15 @@ class ModelFetcher(ErsiliaBase):
             self.logger.debug("Overwriting")
             self.overwrite = True
         self.logger.debug("Fetching in your system, not from DockerHub")
-        self._fetch_not_from_dockerhub(model_id=model_id)
-
+        self._fetch_not_from_dockerhub(model_id=model_id)   
+            
+    def fetch(self, model_id):
+        self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(
                 self._get_bundle_location(model_id), MODEL_SOURCE_FILE
             )
         with open(model_source_file, "w") as f:
             f.write(self.model_source)
-            
-            
-    def fetch(self, model_id):
         self._fetch(model_id)
         self._standard_csv_example(model_id)
+

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -36,6 +36,7 @@ class ModelFetcher(ErsiliaBase):
         force_with_bentoml=False,
         force_with_fastapi=False,
         hosted_url=None,
+        local_dir =None,
     ):
         ErsiliaBase.__init__(
             self, config_json=config_json, credentials_json=credentials_json
@@ -63,6 +64,7 @@ class ModelFetcher(ErsiliaBase):
         self.force_with_bentoml = force_with_bentoml
         self.force_with_fastapi = force_with_fastapi
         self.hosted_url = hosted_url
+        self.local_dir = local_dir 
         
         self.logger.debug("Getting model source")        
         sources = {
@@ -72,7 +74,8 @@ class ModelFetcher(ErsiliaBase):
             self.force_from_hosted: "Hosted services",
             self.force_with_bentoml: "Bentoml",
             self.force_with_fastapi: "Fastapi",
-            self.hosted_url is not None: "Hosted URL"
+            self.hosted_url is not None: "Hosted URL",
+            self.local_dir is not None: "Local path"
         }
         
         self.model_source = next((source for condition, source in sources.items() if condition), "DockerHub")       

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -14,7 +14,7 @@ from ...utils.exceptions_utils.fetch_exceptions import (
     NotInstallableWithBentoML,
 )
 from ...utils.exceptions_utils.throw_ersilia_exception import throw_ersilia_exception
-from ...default import PACK_METHOD_BENTOML, PACK_METHOD_FASTAPI, MODEL_SOURCE_FILE
+from ...default import PACK_METHOD_BENTOML, PACK_METHOD_FASTAPI, EOS, MODEL_SOURCE_FILE
 
 from . import STATUS_FILE, DONE_TAG
 
@@ -235,11 +235,8 @@ class ModelFetcher(ErsiliaBase):
             
     def fetch(self, model_id):
         self.logger.debug("Writing model source to file")
-        model_source_file = os.path.join(
-                self._get_bundle_location(model_id), MODEL_SOURCE_FILE
-            )
+        model_source_file = os.path.join(EOS, MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:
             f.write(self.model_source)
         self._fetch(model_id)
         self._standard_csv_example(model_id)
-


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

Keeping track of where a model was fetched from, whether a repository or storage location seems crucial, a model source descriptor was created to store these values.

**Changes to be made**

- Created a model_source file.
- Added a  `_get_model_source` method to the information class.
- Included model source in the data response payload in the get method.
- Modified the code to also include local path.


**Status**

- The get method returns a data response payload that includes the model source, along with other attributes such as pack mode, service class, API schema, size, metadata, and card."
- Information.json file now includes model source in its data object.
- Model source is not currently reflected in information.json for models fetched from DockerHub.

**To do**

- Create Datastore for Ersilia catalog.
- Reflect correct memory, service class, and model source information in the information.json file, particularly in the case of a model getting fetched from DockerHub.

Related to #1196 