### PR TITLE
Reflecting correct values in Model information file

### DIFF
--- a/ersilia/hub/pull/pull.py
+++ b/ersilia/hub/pull/pull.py
@@ -1,6 +1,7 @@
 import requests
 import subprocess
 import tempfile
+import json
 import os
 import re
 
@@ -13,7 +14,7 @@ from ...utils.exceptions_utils.pull_exceptions import (
 )
 
 from ...utils.docker import SimpleDocker
-from ...default import DOCKERHUB_ORG, DOCKERHUB_LATEST_TAG
+from ...default import DOCKERHUB_ORG, DOCKERHUB_LATEST_TAG, EOS, MODEL_SIZE_FILE
 
 PULL_IMAGE = os.environ.get("PULL_IMAGE", "Y")
 
@@ -140,6 +141,10 @@ class ModelPuller(ErsiliaBase):
             size = self._get_size_of_local_docker_image_in_mb()
             if size:
                 self.logger.debug("Size of image {0} MB".format(size))
+                path = os.path.join(EOS, MODEL_SIZE_FILE)
+                with open(path, "w") as f:
+                    json.dump({"size": size, "units": "MB"}, f, indent=4)
+                self.logger.debug("Size written to {}".format(path))
             else:
                 self.logger.warning("Could not obtain size of image")
             # except: #TODO add better error


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

For models that are fetched from docker,   they have their information file being copied from the container storage to the host machine, this might lead to some incorrect data schema as the file being copied is a representation of the model environment inside the container and not the one on the host machine.

**Changes to be made**

Added a modify_information method to docker functionality, to modify the content of what is being copied from docker container.

**Status**

The information file now reflects the correct service class and size for model's fetched from DockerHub.

[information.json](https://github.com/user-attachments/files/16302518/information.json)


**To do**

Include model source value to model information file copied from container storage.


Related to #1196 