### PR TITLE
Resolving concurrency conflcts during fetching operation 

### DIFF
--- a/ersilia/serve/autoservice.py
+++ b/ersilia/serve/autoservice.py
@@ -16,6 +16,7 @@ from .api import Api
 from ..db.environments.managers import DockerManager
 from .. import ErsiliaBase
 from ..utils import tmp_pid_file
+from ..utils.session import get_session_id
 
 from ..default import (
     DEFAULT_BATCH_SIZE,
@@ -315,10 +316,11 @@ class AutoService(ErsiliaBase):
         self._kill_pids(pids)
 
     def clean_temp_dir(self):
+        session_id = get_session_id()
         self.logger.debug("Cleaning temp dir")
         tmp_folder = tempfile.gettempdir()
         for d in os.listdir(tmp_folder):
-            if "ersilia-" in d:
+            if f"ersilia-{session_id}-" in d:
                 d = os.path.join(tmp_folder, d)
                 self.logger.debug("Flushing temporary directory {0}".format(d))
                 try:
@@ -395,3 +397,4 @@ class AutoService(ErsiliaBase):
             if api_name not in self._meta:
                 self._meta = {api_name: _api.meta()}
             yield result
+

--- a/ersilia/utils/logging.py
+++ b/ersilia/utils/logging.py
@@ -5,14 +5,16 @@ from pathlib import Path
 import tempfile
 from loguru import logger
 from ..default import LOGGING_FILE, CURRENT_LOGGING_FILE, VERBOSE_FILE
-from ..utils.session import get_session_dir
+from ..utils.session import get_session_dir, get_session_id
 
 
 ROTATION = "10 MB"
 
 
 def make_temp_dir(prefix):
-    tmp_dir = tempfile.mkdtemp(prefix=prefix)
+    session_id = get_session_id()
+    prefix_with_session = f"{prefix}{session_id}-"
+    tmp_dir = tempfile.mkdtemp(prefix=prefix_with_session)
     tmp_dirname = os.path.basename(tmp_dir)
     logs_tmp_dir = os.path.join(get_session_dir(), "logs", "tmp")
     if not os.path.exists(logs_tmp_dir):
@@ -98,3 +100,4 @@ class Logger(object):
 
 
 logger = Logger()
+


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

A session ID mechanism to manage resource allocation during fetching, ensuring the successful execution of models running simultaneously across different sessions.

**Changes to be made**

Updated the tmp directory prefix to include Session PID.

**Status**

Simultaneous fetching of models from different sources now works seamlessly. Ersilia no longer attempts to shut down Docker containers for models pulled from Docker Hub running in other sessions.

**To do**

Resolve concurrency conflicts in serving and running predictions.

Related to #1197  