### PR TITLE
Bump rdkit version (#1304)

### DIFF
--- a/ersilia/setup/requirements/compound.py
+++ b/ersilia/setup/requirements/compound.py
@@ -11,7 +11,7 @@ class RdkitRequirement(object):
             self.install()
 
     def install(self):
-        run_command("python -m pip install rdkit-pypi")
+        run_command("python -m pip install rdkit==2023.9.1")
 
 
 class ChemblWebResourceClientRequirement(object):


### PR DESCRIPTION
* replace deprecated rdkit-pypi with rdkit package

* pin rdkit version to 2023.9.1

Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [ x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x ] Have you written new tests for your core changes, as applicable?
- [ x] Have you successfully ran tests with your changes locally?

Related to #1304