### PR TITLE
Fetch CLI unnecessary docker and model checkup

### DIFF
--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -6,6 +6,7 @@ import importlib
 
 from .lazy_fetchers.dockerhub import ModelDockerHubFetcher
 from .lazy_fetchers.hosted import ModelHostedFetcher
+from .register.standard_example import ModelStandardExample
 from ...db.hubdata.json_models_interface import JsonModelsInterface
 from ... import ErsiliaBase
 from ...hub.fetch.actions.template_resolver import TemplateResolver
@@ -213,6 +214,10 @@ class ModelFetcher(ErsiliaBase):
             return True
         else:
             return False
+
+    def _standard_csv_example(self, model_id):
+        ms = ModelStandardExample(model_id=model_id, config_json=self.config_json)
+        ms.run()
     
     def _fetch(self, model_id):
         
@@ -235,6 +240,7 @@ class ModelFetcher(ErsiliaBase):
 
     def fetch(self, model_id):
         self._fetch(model_id)
+        self._standard_csv_example(model_id)
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -6,7 +6,6 @@ import importlib
 
 from .lazy_fetchers.dockerhub import ModelDockerHubFetcher
 from .lazy_fetchers.hosted import ModelHostedFetcher
-from .register.standard_example import ModelStandardExample
 from ...db.hubdata.json_models_interface import JsonModelsInterface
 from ... import ErsiliaBase
 from ...hub.fetch.actions.template_resolver import TemplateResolver
@@ -215,10 +214,6 @@ class ModelFetcher(ErsiliaBase):
         else:
             return False
 
-    def _standard_csv_example(self, model_id):
-        ms = ModelStandardExample(model_id=model_id, config_json=self.config_json)
-        ms.run()
-    
     def _fetch(self, model_id):
         
         self.logger.debug("Starting fetching procedure")
@@ -240,7 +235,6 @@ class ModelFetcher(ErsiliaBase):
 
     def fetch(self, model_id):
         self._fetch(model_id)
-        self._standard_csv_example(model_id)
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -134,6 +134,8 @@ class ModelDockerHubFetcher(ErsiliaBase):
 
     @throw_ersilia_exception
     def fetch(self, model_id):
+        if not DockerRequirement().is_active():
+            raise DockerNotActiveError()
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
         mp.pull()

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -134,8 +134,6 @@ class ModelDockerHubFetcher(ErsiliaBase):
 
     @throw_ersilia_exception
     def fetch(self, model_id):
-        if not DockerRequirement().is_active():
-            raise DockerNotActiveError()
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
         mp.pull()


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [ ] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

The Docker status check and standard model example run has been removed since they appeared to be a performance bottleneck and unnecessary as described in detail (#1299).

Related to #1299