### PR TITLE
Update card.py

### DIFF
--- a/ersilia/hub/content/card.py
+++ b/ersilia/hub/content/card.py
@@ -66,7 +66,6 @@ class BaseInformation(ErsiliaBase):
         self._mode = None
         self._task = None
         self._input = None
-
         self._input_shape = None
         self._output = None
         self._output_type = None
@@ -211,6 +210,8 @@ class BaseInformation(ErsiliaBase):
 
     @output.setter
     def output(self, new_output):
+        if type(new_output) is str:
+            new_output = [new_output]
         default_output = self._read_default_fields("Output")
         for no in new_output:
             if no not in default_output:
@@ -223,6 +224,8 @@ class BaseInformation(ErsiliaBase):
 
     @output_type.setter
     def output_type(self, new_output_type):
+        if type(new_output_type) is str:
+            new_output_type = [new_output_type]
         default_output_type = self._read_default_fields("Output Type")
         for no in new_output_type:
             if no not in default_output_type:
@@ -334,6 +337,8 @@ class BaseInformation(ErsiliaBase):
 
     @docker_architecture.setter
     def docker_architecture(self, new_docker_architecture):
+        if type(new_docker_architecture) is str:
+            new_docker_architecture = [new_docker_architecture]
         for d in new_docker_architecture:
             if d not in self._read_default_fields("Docker Architecture"):
                 raise DockerArchitectureInformationError


### PR DESCRIPTION
This pull request includes several changes to the `ersilia/hub/content/card.py` file, primarily focusing on improving the robustness of setter methods by ensuring that input values are converted to lists if they are provided as strings.

Enhancements to setter methods:

* `output` setter: Added a check to convert `new_output` to a list if it is provided as a string. (`ersilia/hub/content/card.py`, [ersilia/hub/content/card.pyR213-R214](diffhunk://#diff-2575e67f6461725af079a8037913e2f5546d1c02a515b89e350ca1a46d66532aR213-R214))
* `output_type` setter: Added a check to convert `new_output_type` to a list if it is provided as a string. (`ersilia/hub/content/card.py`, [ersilia/hub/content/card.pyR227-R228](diffhunk://#diff-2575e67f6461725af079a8037913e2f5546d1c02a515b89e350ca1a46d66532aR227-R228))
* `docker_architecture` setter: Added a check to convert `new_docker_architecture` to a list if it is provided as a string. (`ersilia/hub/content/card.py`, [ersilia/hub/content/card.pyR340-R341](diffhunk://#diff-2575e67f6461725af079a8037913e2f5546d1c02a515b89e350ca1a46d66532aR340-R341))

Minor cleanup:

* Removed an unnecessary blank line in the `__init__` method. (`ersilia/hub/content/card.py`, [ersilia/hub/content/card.pyL69](diffhunk://#diff-2575e67f6461725af079a8037913e2f5546d1c02a515b89e350ca1a46d66532aL69))