### PR TITLE
Add negative unit test for is_key_header in test_compound_identifier.py

### DIFF
--- a/test/test_compound_identifier.py
+++ b/test/test_compound_identifier.py
@@ -9,3 +9,7 @@ def compound_identifier():
 def test_is_input_header_positive(compound_identifier, header):
     """Test that valid input headers return True."""
     assert compound_identifier.is_input_header(header) is True
+
+@pytest.mark.parametrize("header", ["id","smiles","inchi","input", "some_header", "random", "header", ""])
+def test_is_key_header_negative(compound_identifier, header):
+    assert not compound_identifier.is_key_header(header)


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**
Added a negative test for the is_key_header method in the CompoundIdentifier class. The goal is to make ensure that any input not matching "key" or "inchikey" in any case format should return false

**Changes to be made**
- Added `test_is_key_header_negative` test function in test_compound_identifier.py
- The test contains string of input header that is not "key", "inchikey"
- The list include invalid header that are similar to the valid input

**Status**
- Created the negative test for is_key_header
- Ran the test locally using pytest. Output of running the test [is_key_header.log](https://github.com/user-attachments/files/17414779/is_key_header.log) 

**To do**
Further unit test for other identifier

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #1319 