### PR TITLE
Add nci_smiles_to_inchikey test

### DIFF
--- a/test/test_compound_identifier.py
+++ b/test/test_compound_identifier.py
@@ -15,10 +15,21 @@ def test_is_key_header_positive(compound_identifier, header):
     """Test that valid key headers return True."""
     assert compound_identifier.is_key_header(header) is True
 
-@pytest.mark.parametrize("inchikey", [
-    ("BSYNRYMUTXBXSQ-UHFFFAOYSA-N"),  
-    ("ADJWIQJVAMXRAO-UHFFFAOYSA-N"),  
-])
-def test_is_inchikey_positive(compound_identifier, inchikey):
-    """Test that valid InChIKeys return True."""
-    assert compound_identifier._is_inchikey(inchikey) is True
+@patch('requests.get')
+def test_nci_smiles_to_inchikey_positive(mock_get, compound_identifier):
+    """Test _nci_smiles_to_inchikey with a mocked positive response."""
+    mock_response = mock_get.return_value
+    mock_response.status_code = 200
+    mock_response.text = "InChIKey=BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+
+    inchikey = compound_identifier._nci_smiles_to_inchikey("CCO")
+    assert inchikey == "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+
+@patch('requests.get')
+def test_nci_smiles_to_inchikey_negative(mock_get, compound_identifier):
+    """Test _nci_smiles_to_inchikey with a mocked negative response."""
+    mock_response = mock_get.return_value
+    mock_response.status_code = 404  
+
+    inchikey = compound_identifier._nci_smiles_to_inchikey("invalid_smiles")
+    assert inchikey is None

--- a/test/test_compound_identifier.py
+++ b/test/test_compound_identifier.py
@@ -14,3 +14,11 @@ def test_is_input_header_positive(compound_identifier, header):
 def test_is_key_header_positive(compound_identifier, header):
     """Test that valid key headers return True."""
     assert compound_identifier.is_key_header(header) is True
+
+@pytest.mark.parametrize("inchikey", [
+    ("BSYNRYMUTXBXSQ-UHFFFAOYSA-N"),  
+    ("ADJWIQJVAMXRAO-UHFFFAOYSA-N"),  
+])
+def test_is_inchikey_positive(compound_identifier, inchikey):
+    """Test that valid InChIKeys return True."""
+    assert compound_identifier._is_inchikey(inchikey) is True


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**
This pull request adds new positive and negative tests for the `_nci_smiles_to_inchikey` function of the `CompoundIdentifier` class. These tests mock successful and failed API responses to ensure the function behaves correctly under different conditions.


**Changes to be made**
1. Added two new tests:  
   - `test_nci_smiles_to_inchikey_positive` for valid SMILES to InChIKey conversion.  
   - `test_nci_smiles_to_inchikey_negative` to test handling of invalid SMILES input with a 404 response.
2. Used `@patch` to mock API calls to ensure the tests don't rely on external dependencies.

**Status**

_Replace this line with what you have done so far..._

**To do**

_If this is a work in progress, Replace this line with your next steps_

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #1319 