### PR TITLE
Performance Improvement on the Airtable Interface(#1299)

### DIFF
--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -1,4 +1,5 @@
 import click
+import asyncio
 from . import ersilia_cli
 from .. import echo
 from ...hub.fetch.fetch import ModelFetcher
@@ -9,7 +10,7 @@ def fetch_cmd():
     """Create fetch commmand"""
 
     def _fetch(mf, model_id):
-        mf.fetch(model_id)
+       asyncio.run(mf.fetch(model_id))
 
     # Example usage: ersilia fetch {MODEL}
     @ersilia_cli.command(

--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -1,5 +1,4 @@
 import click
-import asyncio
 from . import ersilia_cli
 from .. import echo
 from ...hub.fetch.fetch import ModelFetcher
@@ -10,7 +9,7 @@ def fetch_cmd():
     """Create fetch commmand"""
 
     def _fetch(mf, model_id):
-       asyncio.run(mf.fetch(model_id))
+        mf.fetch(model_id)
 
     # Example usage: ersilia fetch {MODEL}
     @ersilia_cli.command(

--- a/ersilia/db/hubdata/interfaces.py
+++ b/ersilia/db/hubdata/interfaces.py
@@ -1,5 +1,6 @@
 import requests
 import importlib
+import pyairtable
 from ... import ErsiliaBase
 from ...default import AIRTABLE_MODEL_HUB_BASE_ID, AIRTABLE_MODEL_HUB_TABLE_NAME
 from ...setup.requirements.pyairtable import PyAirtableRequirement
@@ -7,44 +8,44 @@ from ...setup.requirements.pyairtable import PyAirtableRequirement
 AIRTABLE_MAX_ROWS = 100000
 AIRTABLE_PAGE_SIZE = 100
 
-
 class AirtableInterface(ErsiliaBase):
     def __init__(self, config_json):
-        ErsiliaBase.__init__(self, config_json=config_json)
+        super().__init__(config_json=config_json)
         self.base_id = AIRTABLE_MODEL_HUB_BASE_ID
         self.table_name = AIRTABLE_MODEL_HUB_TABLE_NAME
         self.max_rows = AIRTABLE_MAX_ROWS
         self.page_size = AIRTABLE_PAGE_SIZE
         self.write_api_key = None
+
+        self.read_only_api_key = None
         self.table = self._create_table(api_key=self._get_read_only_airtable_api_key())
 
     def _create_table(self, api_key):
-        pyairtable_req = PyAirtableRequirement()
-        if not pyairtable_req.is_installed():
-            self.logger.debug("Installing PyAirTable from pip")
-            pyairtable_req.install()
-        pyairtable = importlib.import_module("pyairtable")
         return pyairtable.Table(api_key, self.base_id, self.table_name)
 
-    @staticmethod
-    def _get_read_only_airtable_api_key():
+    def _get_read_only_airtable_api_key(self):
+        if self.read_only_api_key:
+            return self.read_only_api_key
+
         url = "https://ersilia-model-hub.s3.eu-central-1.amazonaws.com/read_only_keys.json"
-        r = requests.get(url)
-        data = r.json()
-        return data["AIRTABLE_READONLY_API_KEY"]
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+        self.read_only_api_key = data["AIRTABLE_READONLY_API_KEY"]
+        return self.read_only_api_key
 
     def set_write_api_key(self, write_api_key):
         self.write_api_key = write_api_key
         self.table = self._create_table(api_key=write_api_key)
 
     def items(self):
+        """Efficiently yield records using pagination."""
         for records in self.table.iterate(
-            page_size=self.page_size, max_records=self.max_rows
+            page_size=self.page_size, 
+            max_records=self.max_rows
         ):
-            for record in records:
-                yield record
+            yield from records
 
     def items_all(self):
-        records = self.table.all()
-        for record in records:
-            yield record
+        """Avoid using `all` to prevent memory overload on large tables."""
+        return self.items()

--- a/ersilia/db/hubdata/json_models_interface.py
+++ b/ersilia/db/hubdata/json_models_interface.py
@@ -10,7 +10,6 @@ import requests
 class JsonModelsInterface(ErsiliaBase):
     def __init__(self, config_json):
         ErsiliaBase.__init__(self, config_json=config_json)
-        # self.cache_dir = 
         self.json_file_name = MODELS_JSON
         self.url = f"https://{ERSILIA_MODEL_HUB_S3_BUCKET}.s3.eu-central-1.amazonaws.com/{MODELS_JSON}"
 

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -156,9 +156,10 @@ class ModelFetcher(ErsiliaBase):
         else:
             self.logger.debug("Model already exists in your local, skipping fetching")
 
-    def _fetch_from_dockerhub(self, model_id):
+
+    async def _fetch_from_dockerhub(self, model_id):
         self.logger.debug("Fetching from DockerHub")
-        self.model_dockerhub_fetcher.fetch(model_id=model_id)
+        await self.model_dockerhub_fetcher.fetch(model_id=model_id)
 
     def _fetch_from_hosted(self, model_id):
         self.logger.debug("Fetching from hosted")
@@ -214,7 +215,7 @@ class ModelFetcher(ErsiliaBase):
         else:
             return False
 
-    def _fetch(self, model_id):
+    async def _fetch(self, model_id):
         
         self.logger.debug("Starting fetching procedure")
         do_dockerhub = self._decide_if_use_dockerhub(model_id=model_id)
@@ -233,10 +234,9 @@ class ModelFetcher(ErsiliaBase):
         self.logger.debug("Fetching in your system, not from DockerHub")
         self._fetch_not_from_dockerhub(model_id=model_id)
 
-    def fetch(self, model_id):
-        self._fetch(model_id)
+    async def fetch(self, model_id):
+        await self._fetch(model_id)  
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:
             f.write(self.model_source)
-

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -6,6 +6,7 @@ import importlib
 
 from .lazy_fetchers.dockerhub import ModelDockerHubFetcher
 from .lazy_fetchers.hosted import ModelHostedFetcher
+from .register.standard_example import ModelStandardExample
 from ...db.hubdata.json_models_interface import JsonModelsInterface
 from ... import ErsiliaBase
 from ...hub.fetch.actions.template_resolver import TemplateResolver
@@ -213,6 +214,10 @@ class ModelFetcher(ErsiliaBase):
             return True
         else:
             return False
+
+    def _standard_csv_example(self, model_id):
+        ms = ModelStandardExample(model_id=model_id, config_json=self.config_json)
+        ms.run()
     
     def _fetch(self, model_id):
         
@@ -235,6 +240,7 @@ class ModelFetcher(ErsiliaBase):
 
     def fetch(self, model_id):
         self._fetch(model_id)
+        self._standard_csv_example(model_id)
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -156,9 +156,10 @@ class ModelFetcher(ErsiliaBase):
         else:
             self.logger.debug("Model already exists in your local, skipping fetching")
 
-    def _fetch_from_dockerhub(self, model_id):
+
+    async def _fetch_from_dockerhub(self, model_id):
         self.logger.debug("Fetching from DockerHub")
-        self.model_dockerhub_fetcher.fetch(model_id=model_id)
+        await self.model_dockerhub_fetcher.fetch(model_id=model_id)
 
     def _fetch_from_hosted(self, model_id):
         self.logger.debug("Fetching from hosted")
@@ -214,7 +215,7 @@ class ModelFetcher(ErsiliaBase):
         else:
             return False
 
-    def _fetch(self, model_id):
+    async def _fetch(self, model_id):
         
         self.logger.debug("Starting fetching procedure")
         do_dockerhub = self._decide_if_use_dockerhub(model_id=model_id)
@@ -233,8 +234,8 @@ class ModelFetcher(ErsiliaBase):
         self.logger.debug("Fetching in your system, not from DockerHub")
         self._fetch_not_from_dockerhub(model_id=model_id)
 
-    def fetch(self, model_id):
-        self._fetch(model_id)
+    async def fetch(self, model_id):
+        await self._fetch(model_id)  
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -6,7 +6,6 @@ import importlib
 
 from .lazy_fetchers.dockerhub import ModelDockerHubFetcher
 from .lazy_fetchers.hosted import ModelHostedFetcher
-from .register.standard_example import ModelStandardExample
 from ...db.hubdata.json_models_interface import JsonModelsInterface
 from ... import ErsiliaBase
 from ...hub.fetch.actions.template_resolver import TemplateResolver
@@ -215,10 +214,6 @@ class ModelFetcher(ErsiliaBase):
         else:
             return False
 
-    def _standard_csv_example(self, model_id):
-        ms = ModelStandardExample(model_id=model_id, config_json=self.config_json)
-        ms.run()
-    
     def _fetch(self, model_id):
         
         self.logger.debug("Starting fetching procedure")
@@ -240,7 +235,6 @@ class ModelFetcher(ErsiliaBase):
 
     def fetch(self, model_id):
         self._fetch(model_id)
-        self._standard_csv_example(model_id)
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -156,10 +156,9 @@ class ModelFetcher(ErsiliaBase):
         else:
             self.logger.debug("Model already exists in your local, skipping fetching")
 
-
-    async def _fetch_from_dockerhub(self, model_id):
+    def _fetch_from_dockerhub(self, model_id):
         self.logger.debug("Fetching from DockerHub")
-        await self.model_dockerhub_fetcher.fetch(model_id=model_id)
+        self.model_dockerhub_fetcher.fetch(model_id=model_id)
 
     def _fetch_from_hosted(self, model_id):
         self.logger.debug("Fetching from hosted")
@@ -215,7 +214,7 @@ class ModelFetcher(ErsiliaBase):
         else:
             return False
 
-    async def _fetch(self, model_id):
+    def _fetch(self, model_id):
         
         self.logger.debug("Starting fetching procedure")
         do_dockerhub = self._decide_if_use_dockerhub(model_id=model_id)
@@ -234,8 +233,8 @@ class ModelFetcher(ErsiliaBase):
         self.logger.debug("Fetching in your system, not from DockerHub")
         self._fetch_not_from_dockerhub(model_id=model_id)
 
-    async def fetch(self, model_id):
-        await self._fetch(model_id)  
+    def fetch(self, model_id):
+        self._fetch(model_id)
         self.logger.debug("Writing model source to file")
         model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
         with open(model_source_file, "w") as f:

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -134,6 +134,8 @@ class ModelDockerHubFetcher(ErsiliaBase):
 
     @throw_ersilia_exception
     def fetch(self, model_id):
+        if not DockerRequirement().is_active():
+            raise DockerNotActiveError()
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
         mp.pull()

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -1,6 +1,5 @@
 import os
 import json
-import asyncio
 from ..register.register import ModelRegisterer
 
 from .... import ErsiliaBase, throw_ersilia_exception
@@ -20,9 +19,10 @@ from ....utils.docker import SimpleDocker, resolve_pack_method_docker, PACK_METH
 from ....utils.exceptions_utils.fetch_exceptions import DockerNotActiveError
 from .. import STATUS_FILE
 
+
 class ModelDockerHubFetcher(ErsiliaBase):
     def __init__(self, overwrite=None, config_json=None):
-        super().__init__(config_json=config_json, credentials_json=None)
+        ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         self.simple_docker = SimpleDocker()
         self.overwrite = overwrite
 
@@ -42,7 +42,7 @@ class ModelDockerHubFetcher(ErsiliaBase):
             return True
         return False
 
-    async def write_apis(self, model_id):
+    def write_apis(self, model_id):
         self.logger.debug("Writing APIs")
         di = PulledDockerImageService(
             model_id=model_id, config_json=self.config_json, preferred_port=None
@@ -50,20 +50,9 @@ class ModelDockerHubFetcher(ErsiliaBase):
         di.serve()
         di.close()
 
-    async def _copy_from_bentoml_image(self, model_id, file):
-        fr_file = f"/root/eos/dest/{model_id}/{file}"
-        to_file = f"{EOS}/dest/{model_id}/{file}"
-        await self.simple_docker.cp_from_image(
-            img_path=fr_file,
-            local_path=to_file,
-            org=DOCKERHUB_ORG,
-            img=model_id,
-            tag=DOCKERHUB_LATEST_TAG,
-        )
-
-    async def _copy_from_ersiliapack_image(self, model_id, file):
-        fr_file = f"/root/{file}"
-        to_file = f"{EOS}/dest/{model_id}/{file}"
+    def _copy_from_bentoml_image(self, model_id, file):
+        fr_file = "/root/eos/dest/{0}/{1}".format(model_id, file)
+        to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, file)
         self.simple_docker.cp_from_image(
             img_path=fr_file,
             local_path=to_file,
@@ -72,30 +61,41 @@ class ModelDockerHubFetcher(ErsiliaBase):
             tag=DOCKERHUB_LATEST_TAG,
         )
 
-    async def _copy_from_image_to_local(self, model_id, file):
+    def _copy_from_ersiliapack_image(self, model_id, file):
+        fr_file = "/root/{0}".format(file)
+        to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, file)
+        self.simple_docker.cp_from_image(
+            img_path=fr_file,
+            local_path=to_file,
+            org=DOCKERHUB_ORG,
+            img=model_id,
+            tag=DOCKERHUB_LATEST_TAG,
+        )
+
+    def _copy_from_image_to_local(self, model_id, file):
         pack_method = resolve_pack_method_docker(model_id)
         if pack_method == PACK_METHOD_BENTOML:
             self._copy_from_bentoml_image(model_id, file)
         else:
             self._copy_from_ersiliapack_image(model_id, file)
 
-    async def copy_information(self, model_id):
+    def copy_information(self, model_id):
         self.logger.debug("Copying information file from model container")
         self._copy_from_image_to_local(model_id, INFORMATION_FILE)
 
-    async def copy_metadata(self, model_id):
+    def copy_metadata(self, model_id):
         self.logger.debug("Copying api_schema_file file from model container")
         self._copy_from_image_to_local(model_id, API_SCHEMA_FILE)
 
-    async def copy_status(self, model_id):
+    def copy_status(self, model_id):
         self.logger.debug("Copying status file from model container")
         self._copy_from_image_to_local(model_id, STATUS_FILE)
-
-    async def copy_example_if_available(self, model_id):
-        # This needs to accommodate ersilia pack
+                                       
+    def copy_example_if_available(self, model_id):
+        # TODO This also needs to change to accomodate ersilia pack
         for pf in PREDEFINED_EXAMPLE_FILES:
-            fr_file = f"/root/eos/dest/{model_id}/{pf}"
-            to_file = f"{EOS}/dest/{model_id}/input.csv"
+            fr_file = "/root/eos/dest/{0}/{1}".format(model_id, pf)
+            to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, "input.csv")
             try:
                 self.simple_docker.cp_from_image(
                     img_path=fr_file,
@@ -108,9 +108,12 @@ class ModelDockerHubFetcher(ErsiliaBase):
             except:
                 self.logger.debug("Could not find example file in docker image")
 
-    async def modify_information(self, model_id):
+    def modify_information(self, model_id):
         """
         Modify the information file being copied from docker container to the host machine.
+        :param file: The model information file being copied.
+        :param service_class_file: File containing the model service class.
+        :size_file: File containing the size of the pulled docker image.
         """
         information_file = os.path.join(self._model_path(model_id), INFORMATION_FILE)
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
@@ -121,26 +124,24 @@ class ModelDockerHubFetcher(ErsiliaBase):
             self.logger.error("Information file not found, not modifying anything")
             return None
 
+        # Using this literal here to prevent a file read 
+        # from service class file for a model fetched through DockerHub
+        # since we already know the service class.
         data["service_class"] = "pulled_docker"
-        data["size"] = mp._get_size_of_local_docker_image_in_mb() 
-
+        data["size"] = mp._get_size_of_local_docker_image_in_mb()  # TODO this should probably be a util function 
         with open(information_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 
     @throw_ersilia_exception
-    async def fetch(self, model_id):
+    def fetch(self, model_id):
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
-        # Asynchronous pulling
-        await mp.async_pull()
+        mp.pull()
         mr = ModelRegisterer(model_id=model_id, config_json=self.config_json)
-        # Asynchronous and concurent execution
-        await asyncio.gather(
-            mr.register(is_from_dockerhub=True),
-            self.write_apis(model_id),
-            self.copy_information(model_id),
-            self.modify_information(model_id),
-            self.copy_metadata(model_id),
-            self.copy_status(model_id),
-            self.copy_example_if_available(model_id)
-        )
+        mr.register(is_from_dockerhub=True)
+        self.write_apis(model_id)
+        self.copy_information(model_id)
+        self.modify_information(model_id)
+        self.copy_metadata(model_id)
+        self.copy_status(model_id)
+        self.copy_example_if_available(model_id)

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -134,8 +134,6 @@ class ModelDockerHubFetcher(ErsiliaBase):
 
     @throw_ersilia_exception
     def fetch(self, model_id):
-        if not DockerRequirement().is_active():
-            raise DockerNotActiveError()
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
         mp.pull()

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -1,5 +1,6 @@
 import os
 import json
+import asyncio
 from ..register.register import ModelRegisterer
 
 from .... import ErsiliaBase, throw_ersilia_exception
@@ -19,10 +20,9 @@ from ....utils.docker import SimpleDocker, resolve_pack_method_docker, PACK_METH
 from ....utils.exceptions_utils.fetch_exceptions import DockerNotActiveError
 from .. import STATUS_FILE
 
-
 class ModelDockerHubFetcher(ErsiliaBase):
     def __init__(self, overwrite=None, config_json=None):
-        ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
+        super().__init__(config_json=config_json, credentials_json=None)
         self.simple_docker = SimpleDocker()
         self.overwrite = overwrite
 
@@ -42,7 +42,7 @@ class ModelDockerHubFetcher(ErsiliaBase):
             return True
         return False
 
-    def write_apis(self, model_id):
+    async def write_apis(self, model_id):
         self.logger.debug("Writing APIs")
         di = PulledDockerImageService(
             model_id=model_id, config_json=self.config_json, preferred_port=None
@@ -50,9 +50,20 @@ class ModelDockerHubFetcher(ErsiliaBase):
         di.serve()
         di.close()
 
-    def _copy_from_bentoml_image(self, model_id, file):
-        fr_file = "/root/eos/dest/{0}/{1}".format(model_id, file)
-        to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, file)
+    async def _copy_from_bentoml_image(self, model_id, file):
+        fr_file = f"/root/eos/dest/{model_id}/{file}"
+        to_file = f"{EOS}/dest/{model_id}/{file}"
+        await self.simple_docker.cp_from_image(
+            img_path=fr_file,
+            local_path=to_file,
+            org=DOCKERHUB_ORG,
+            img=model_id,
+            tag=DOCKERHUB_LATEST_TAG,
+        )
+
+    async def _copy_from_ersiliapack_image(self, model_id, file):
+        fr_file = f"/root/{file}"
+        to_file = f"{EOS}/dest/{model_id}/{file}"
         self.simple_docker.cp_from_image(
             img_path=fr_file,
             local_path=to_file,
@@ -61,41 +72,30 @@ class ModelDockerHubFetcher(ErsiliaBase):
             tag=DOCKERHUB_LATEST_TAG,
         )
 
-    def _copy_from_ersiliapack_image(self, model_id, file):
-        fr_file = "/root/{0}".format(file)
-        to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, file)
-        self.simple_docker.cp_from_image(
-            img_path=fr_file,
-            local_path=to_file,
-            org=DOCKERHUB_ORG,
-            img=model_id,
-            tag=DOCKERHUB_LATEST_TAG,
-        )
-
-    def _copy_from_image_to_local(self, model_id, file):
+    async def _copy_from_image_to_local(self, model_id, file):
         pack_method = resolve_pack_method_docker(model_id)
         if pack_method == PACK_METHOD_BENTOML:
             self._copy_from_bentoml_image(model_id, file)
         else:
             self._copy_from_ersiliapack_image(model_id, file)
 
-    def copy_information(self, model_id):
+    async def copy_information(self, model_id):
         self.logger.debug("Copying information file from model container")
         self._copy_from_image_to_local(model_id, INFORMATION_FILE)
 
-    def copy_metadata(self, model_id):
+    async def copy_metadata(self, model_id):
         self.logger.debug("Copying api_schema_file file from model container")
         self._copy_from_image_to_local(model_id, API_SCHEMA_FILE)
 
-    def copy_status(self, model_id):
+    async def copy_status(self, model_id):
         self.logger.debug("Copying status file from model container")
         self._copy_from_image_to_local(model_id, STATUS_FILE)
-                                       
-    def copy_example_if_available(self, model_id):
-        # TODO This also needs to change to accomodate ersilia pack
+
+    async def copy_example_if_available(self, model_id):
+        # This needs to accommodate ersilia pack
         for pf in PREDEFINED_EXAMPLE_FILES:
-            fr_file = "/root/eos/dest/{0}/{1}".format(model_id, pf)
-            to_file = "{0}/dest/{1}/{2}".format(EOS, model_id, "input.csv")
+            fr_file = f"/root/eos/dest/{model_id}/{pf}"
+            to_file = f"{EOS}/dest/{model_id}/input.csv"
             try:
                 self.simple_docker.cp_from_image(
                     img_path=fr_file,
@@ -108,12 +108,9 @@ class ModelDockerHubFetcher(ErsiliaBase):
             except:
                 self.logger.debug("Could not find example file in docker image")
 
-    def modify_information(self, model_id):
+    async def modify_information(self, model_id):
         """
         Modify the information file being copied from docker container to the host machine.
-        :param file: The model information file being copied.
-        :param service_class_file: File containing the model service class.
-        :size_file: File containing the size of the pulled docker image.
         """
         information_file = os.path.join(self._model_path(model_id), INFORMATION_FILE)
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
@@ -124,24 +121,26 @@ class ModelDockerHubFetcher(ErsiliaBase):
             self.logger.error("Information file not found, not modifying anything")
             return None
 
-        # Using this literal here to prevent a file read 
-        # from service class file for a model fetched through DockerHub
-        # since we already know the service class.
         data["service_class"] = "pulled_docker"
-        data["size"] = mp._get_size_of_local_docker_image_in_mb()  # TODO this should probably be a util function 
+        data["size"] = mp._get_size_of_local_docker_image_in_mb() 
+
         with open(information_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 
     @throw_ersilia_exception
-    def fetch(self, model_id):
+    async def fetch(self, model_id):
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")
-        mp.pull()
+        # Asynchronous pulling
+        await mp.async_pull()
         mr = ModelRegisterer(model_id=model_id, config_json=self.config_json)
-        mr.register(is_from_dockerhub=True)
-        self.write_apis(model_id)
-        self.copy_information(model_id)
-        self.modify_information(model_id)
-        self.copy_metadata(model_id)
-        self.copy_status(model_id)
-        self.copy_example_if_available(model_id)
+        # Asynchronous and concurent execution
+        await asyncio.gather(
+            mr.register(is_from_dockerhub=True),
+            self.write_apis(model_id),
+            self.copy_information(model_id),
+            self.modify_information(model_id),
+            self.copy_metadata(model_id),
+            self.copy_status(model_id),
+            self.copy_example_if_available(model_id)
+        )

--- a/ersilia/hub/pull/pull.py
+++ b/ersilia/hub/pull/pull.py
@@ -4,7 +4,8 @@ import tempfile
 import json
 import os
 import re
-
+import asyncio
+import aiofiles
 from ... import ErsiliaBase
 from ...utils.terminal import yes_no_input, run_command
 from ... import throw_ersilia_exception
@@ -85,7 +86,7 @@ class ModelPuller(ErsiliaBase):
             return None
 
     @throw_ersilia_exception
-    def pull(self):
+    async def pull(self):
         if self.is_available_locally():
             if self.overwrite is None:
                 do_pull = yes_no_input(
@@ -116,29 +117,61 @@ class ModelPuller(ErsiliaBase):
                     make_temp_dir(prefix="ersilia-"), "docker_pull.log"
                 )
                 self.logger.debug("Keeping logs of pull in {0}".format(tmp_file))
-                run_command(
-                    "docker pull {0}/{1}:{2} > {3} 2>&1".format(
-                        DOCKERHUB_ORG, self.model_id, DOCKERHUB_LATEST_TAG, tmp_file
-                    )
+
+                # Construct the pull command
+                pull_command = f"docker pull {DOCKERHUB_ORG}/{self.model_id}:{DOCKERHUB_LATEST_TAG} > {tmp_file} 2>&1"
+
+                # Use asyncio to run the pull command asynchronously
+                process = await asyncio.create_subprocess_shell(
+                    pull_command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE
                 )
-                with open(tmp_file, "r") as f:
-                    pull_log = f.read()
+
+                # Wait for the command to complete
+                stdout, stderr = await process.communicate()
+
+                # Handle output
+                if process.returncode != 0:
+                    self.logger.error(f"Pull command failed: {stderr.decode()}")
+                    raise subprocess.CalledProcessError(process.returncode, pull_command)
+                
+                self.logger.debug(stdout.decode())
+
+                # Reading log asynchronously
+                async with aiofiles.open(tmp_file, 'r') as f:
+                    pull_log = await f.read()
                     self.logger.debug(pull_log)
+
                 if re.search(r"no match.*manifest", pull_log):
                     self.logger.warning(
                         "No matching manifest for image {0}".format(self.model_id)
                     )
                     raise DockerConventionalPullError(model=self.model_id)
-                self.logger.debug("Image pulled succesfully!")
+
+                self.logger.debug("Image pulled successfully!")
+
             except DockerConventionalPullError:
                 self.logger.warning(
                     "Conventional pull did not work, Ersilia is now forcing linux/amd64 architecture"
                 )
-                run_command(
-                    "docker pull {0}/{1}:{2} --platform linux/amd64".format(
-                        DOCKERHUB_ORG, self.model_id, DOCKERHUB_LATEST_TAG
-                    )
+                # Force platform specification pull command
+                force_pull_command = f"docker pull {DOCKERHUB_ORG}/{self.model_id}:{DOCKERHUB_LATEST_TAG} --platform linux/amd64"
+
+                # Run forced pull asynchronously
+                process = await asyncio.create_subprocess_shell(
+                    force_pull_command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE
                 )
+
+                stdout, stderr = await process.communicate()
+
+                if process.returncode != 0:
+                    self.logger.error(f"Forced pull command failed: {stderr.decode()}")
+                    raise subprocess.CalledProcessError(process.returncode, force_pull_command)
+
+                self.logger.debug(stdout.decode())
             size = self._get_size_of_local_docker_image_in_mb()
             if size:
                 self.logger.debug("Size of image {0} MB".format(size))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,19 +8,25 @@ readme = "README.md"
 homepage = "https://ersilia.io"
 repository = "https://github.com/ersilia-os/ersilia"
 documentation = "https://ersilia.io/model-hub"
-keywords= ["drug-discovery", "machine-learning", "ersilia", "open-science", "global-health", "model-hub", "infectious-diseases"]
-classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+keywords = [
+    "drug-discovery",
+    "machine-learning",
+    "ersilia",
+    "open-science",
+    "global-health",
+    "model-hub",
+    "infectious-diseases",
 ]
-packages = [
-    {include = "ersilia"},
+classifiers = [
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+packages = [{ include = "ersilia" }]
 include = [
     "ersilia/hub/content/metadata/*.txt",
     "ersilia/io/types/examples/*.tsv",
@@ -31,8 +37,8 @@ python = ">=3.7"
 inputimeout = "^1.0.4"
 emoji = "^2.8.0"
 validators = [
-    {version="0.20.0", python="3.7.*"},
-    {version="~0.21.0", python=">=3.8"},
+    { version = "0.20.0", python = "3.7.*" },
+    { version = "~0.21.0", python = ">=3.8" },
 ]
 
 psutil = ">=5.9.0"
@@ -46,16 +52,20 @@ docker = "^6.1.3"
 boto3 = "^1.28.40"
 requests = "<=2.31.0"
 numpy = "<=1.26.4"
-isaura = {version="0.1", optional=true}
+pyairtable = [
+    { version = "<2", markers = "python_version == '3.7'" },
+    { version = "<3", markers = "python_version > '3.7'" },
+]
+isaura = { version = "0.1", optional = true }
 aiofiles = "<=24.1.0"
 aiohttp = "<=3.10.9"
-pytest = {version = "^7.4.0", optional = true}
-pytest-asyncio = {version = "<=0.24.0", optional = true}
-pytest-benchmark = {version = "<=4.0.0", optional = true}
-fuzzywuzzy = {version = "^0.18.0", optional = true}
-sphinx = {version = ">=5.3.0", optional = true} # For compatibility with python 3.7.x
-jinja2 = {version = "^3.1.2", optional = true}
-scipy = {version = "<=1.10.0", optional = true}
+pytest = { version = "^7.4.0", optional = true }
+pytest-asyncio = { version = "<=0.24.0", optional = true }
+pytest-benchmark = { version = "<=4.0.0", optional = true }
+fuzzywuzzy = { version = "^0.18.0", optional = true }
+sphinx = { version = ">=5.3.0", optional = true }
+jinja2 = { version = "^3.1.2", optional = true }
+scipy = { version = "<=1.10.0", optional = true }
 
 [tool.poetry.extras]
 # Instead of using poetry dependency groups, we use extras to make it pip installable

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from ersilia.hub.fetch.fetch import ModelFetcher
 from ersilia import ErsiliaModel
 
@@ -18,17 +19,22 @@ def test_model_1():
     assert 1 == 1
 
 
-def test_model_2():
+@pytest.mark.asyncio
+async def test_model_2():
     MODEL_ID = MODELS[1]
     INPUT = "CCCC"
-    ModelFetcher(repo_path=os.path.join(os.getcwd(), "test/models", MODEL_ID)).fetch(
-        MODEL_ID
-    )
+    fetcher = ModelFetcher(repo_path=os.path.join(os.getcwd(), "test/models", MODEL_ID))
+    
+    await fetcher.fetch(MODEL_ID)
+    
     em = ErsiliaModel(MODEL_ID)
     em.serve()
     em.predict(INPUT)
     em.close()
+    
     assert 1 == 1
+
+
 
 
 def test_model_3():


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [ ] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

Description

A few improvement made on the airtable interface as listed below:

changing manual yield with more efficient and auto sub-generator creator yield from
In terms of performance, yield from can be more efficient than manually using yield with a loop. This is because yield from is implemented in C and optimized to handle delegation more efficiently and also has memory improvement. Will report time comparison on the https://github.com/ersilia-os/ersilia/issues/1299.
Using pyairtable is inevitable so instead of installing it during AirtableInterface call, we can install it as requirements, that reduce the AirtableInterface overhead.
Related to https://github.com/ersilia-os/ersilia/issues/1299