### PR TITLE
Make ersilia metadata file agnostic

### DIFF
--- a/ersilia/core/modelbase.py
+++ b/ersilia/core/modelbase.py
@@ -5,6 +5,7 @@ from .. import ErsiliaBase
 from ..hub.content.slug import Slug
 from ..hub.fetch import STATUS_FILE, DONE_TAG
 from ..default import IS_FETCHED_FROM_DOCKERHUB_FILE
+from ..utils.paths import get_metadata_from_base_dir
 
 from ..utils.exceptions_utils.exceptions import InvalidModelIdentifierError
 from .. import throw_ersilia_exception
@@ -47,17 +48,15 @@ class ModelBase(ErsiliaBase):
         return os.path.basename(os.path.abspath(repo_path)).rstrip("/")
 
     def _get_slug_if_available(self, repo_path):
-        metadata_json = os.path.join(repo_path, "metadata.json")
-        if os.path.exists(metadata_json):
-            with open(metadata_json, "r") as f:
-                data = json.load(f)
-            slug = data["Slug"]
-            if slug == "":
-                return None
-            else:
-                return slug
-        else:
+        try:
+            data = get_metadata_from_base_dir(repo_path)
+        except FileNotFoundError:
             return None
+        slug = data["Slug"]
+        if slug == "":
+            return None
+        else:
+            return slug
 
     def is_valid(self):
         if self.model_id is None or self.slug is None:

--- a/ersilia/db/hubdata/samplers.py
+++ b/ersilia/db/hubdata/samplers.py
@@ -10,7 +10,7 @@ from .json_models_interface import JsonModelsInterface
 from ... import ErsiliaBase
 
 
-from ...default import METADATA_JSON_FILE
+from ...utils.paths import get_metadata_from_base_dir
 
 _MODEL_STATUS_READY = "Ready"
 _STATUS_FIELD = "Status"
@@ -85,11 +85,10 @@ class InputSampler(ErsiliaBase):
 
     def _get_input_type_and_shape_from_metadata(self):
         dest_path = self._model_path(self.model_id)
-        metadata_json = os.path.join(dest_path, METADATA_JSON_FILE)
-        if not os.path.exists(metadata_json):
+        try:
+            data = get_metadata_from_base_dir(dest_path)
+        except FileNotFoundError:
             return None
-        with open(metadata_json, "r") as f:
-            data = json.load(f)
         input_type = data[_INPUT_TYPE_FIELD]
         input_shape = data[_INPUT_SHAPE_FIELD]
         return input_type, input_shape

--- a/ersilia/hub/content/card.py
+++ b/ersilia/hub/content/card.py
@@ -52,6 +52,7 @@ from ...default import (
     INFORMATION_FILE,
     METADATA_YAML_FILE,
 )
+from ...utils.paths import get_metadata_from_base_dir
 
 
 class BaseInformation(ErsiliaBase):
@@ -628,13 +629,11 @@ class MetadataCard(ErsiliaBase):
         if model_id is not None:
             dest_dir = self._model_path(model_id=model_id)
             self.logger.debug("Trying to get metadata from: {0}".format(dest_dir))
-            metadata_json = os.path.join(dest_dir, METADATA_JSON_FILE)
-            if os.path.exists(metadata_json):
-                with open(metadata_json, "r") as f:
-                    data = json.load(f)
-                return data
-            else:
+            try:
+                data = get_metadata_from_base_dir(dest_dir)
+            except FileNotFoundError:
                 return None
+            return data
         else:
             return
 

--- a/ersilia/hub/content/information.py
+++ b/ersilia/hub/content/information.py
@@ -12,12 +12,12 @@ from ...default import (
     PACKMODE_FILE,
     API_SCHEMA_FILE,
     MODEL_SIZE_FILE,
-    METADATA_JSON_FILE,
     CARD_FILE,
     SERVICE_CLASS_FILE,
     APIS_LIST_FILE,
     MODEL_SOURCE_FILE,
 )
+from ...utils.paths import get_metadata_from_base_dir
 
 
 class Information(ErsiliaBase):
@@ -70,12 +70,11 @@ class Information(ErsiliaBase):
             return None
 
     def _get_metadata(self):
-        metadata_file = os.path.join(self.dest_folder, METADATA_JSON_FILE)
-        if os.path.exists(metadata_file):
-            with open(metadata_file, "r") as f:
-                return json.load(f)
-        else:
+        try:
+            data = get_metadata_from_base_dir(self.dest_folder)
+        except FileNotFoundError:
             return None
+        return data
 
     def _get_card(self):
         card_file = os.path.join(self.dest_folder, CARD_FILE)

--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -18,6 +18,7 @@ from ....utils.exceptions_utils.fetch_exceptions import (
 from .template_resolver import TemplateResolver
 
 from ....default import S3_BUCKET_URL_ZIP, PREDEFINED_EXAMPLE_FILES
+from ....utils.paths import get_metadata_from_base_dir
 from ....utils.logging import make_temp_dir
 
 MODEL_DIR = "model"
@@ -49,10 +50,16 @@ class ServiceCreator(ErsiliaBase):
         src_dir = os.path.join(self.dest_dir, "src")
         if not os.path.exists(src_dir):
             os.mkdir(src_dir)
-        content = read_file_from_path(
-            os.path.join(ROOT, "..", "inner_template", "src", "service.py")
-        )
-        output_type = read_metadata_section("Output Type")
+        
+        with open(os.path.join(self.dest_dir, "src", "service.py"), "r") as f:
+            content = f.read()
+        
+        
+        try:
+            metadata = get_metadata_from_base_dir(self.dest_dir)
+            output_type = metadata["Output Type"]
+        except (FileNotFoundError, KeyError):
+            output_type = None
         outcome_line_index = -1
         splited = content.splitlines()
         for i, line in enumerate(splited):
@@ -65,7 +72,9 @@ class ServiceCreator(ErsiliaBase):
                 "Float", "String"
             )
         output = "\n".join(splited)
-        write_content(output, "src/service.py")
+        file_path = os.path.join(self.dest_dir, "src", "service.py")
+        with open(file_path, "w") as f:
+            f.write(output)
 
 
 class DockerfileCreator(ErsiliaBase):
@@ -78,10 +87,13 @@ class DockerfileCreator(ErsiliaBase):
         self.logger.debug(
             "Creating Dockerfile for internal usage from a config.yml file"
         )
-        read_metadata_section
-        docker_file = read_file_from_path("Dockerfile")
+        file_path = os.path.join(self.dest_dir, "Dockerfile")
+        with open(file_path, "r") as f:
+            docker_file = f.read()
+
         updated = self._append_commands_to_dockerfile(self.commands, docker_file)
-        write_content("Docker", updated)
+        with open(file_path, "w") as f:
+            f.write(updated)
 
     def _append_commands_to_dockerfile(self, commands, dockerfile_content):
         run_section_end_line = -1
@@ -150,39 +162,6 @@ class TemplatePreparer(BaseAction):
         self._create_pack()
         self._create_dockerfile()
         self._create_service()
-
-
-def read_metadata_section(key):
-    metadata_file = "metadata.json"
-    ##TODO. Ask when where to locate the metadata.
-    with open(metadata_file, "r") as file:
-        data = json.load(file)
-    if key not in data:
-        raise BaseException(f"The key {key} does not exist in the metadata")
-    return data[key]
-
-
-def read_config_yaml_section(key):
-    # TODO. Ask where to located the config.yml
-    yaml_file = "config.yaml"
-    with open(yaml_file, "r") as file:
-        data = yaml.safe_load(file)
-    if key not in data:
-        raise BaseException(f"The key {key} is not in the metadata ")
-    return data[key]
-
-
-##TODO - Ask where to put the files. Do we create a class for them?
-def read_file_from_path(file_path):
-    with open(os.path.join(ROOT, file_path), "r") as file:
-        content = file.read()
-    return content
-
-
-def write_content(file_path, content):
-    with open(os.path.abspath(file_path), "w") as file:
-        file.writelines(content)
-
 
 class ModelRepositoryGetter(BaseAction):
     def __init__(

--- a/ersilia/io/pure.py
+++ b/ersilia/io/pure.py
@@ -2,7 +2,7 @@ import json
 import os
 import numpy as np
 from .. import ErsiliaBase
-from ..default import METADATA_JSON_FILE
+from ..utils.paths import get_metadata_from_base_dir
 
 
 class PureDataTyper(ErsiliaBase):
@@ -78,11 +78,10 @@ class PureDataTyper(ErsiliaBase):
         if self.model_id is None:
             return
         dest = self._model_path(self.model_id)
-        meta_file = os.path.join(dest, METADATA_JSON_FILE)
-        if not os.path.exists(meta_file):
+        try:
+            meta = get_metadata_from_base_dir(dest)
+        except FileNotFoundError:
             return
-        with open(meta_file, "r") as f:
-            meta = json.load(f)
         output_type = meta["Output Type"]
         output_shape = meta["Output Shape"]
         if len(output_type) > 1:

--- a/ersilia/publish/inspect.py
+++ b/ersilia/publish/inspect.py
@@ -2,10 +2,9 @@ from .. import ErsiliaBase
 import requests
 import subprocess
 import time
-import json
 from collections import namedtuple
-from urllib.request import urlopen
 from ..hub.content.card import RepoMetadataFile
+from ..default import METADATA_JSON_FILE
 
 # a namedtuple for the results
 Result = namedtuple("Result", ["success", "details"])
@@ -321,7 +320,7 @@ class ModelInspector(ErsiliaBase):
             "Dockerfile",
             "LICENSE",
             "README.md",
-            "metadata.json",
+            METADATA_JSON_FILE,
             "pack.py",
             ".gitattributes",
         ]

--- a/ersilia/publish/metadata.py
+++ b/ersilia/publish/metadata.py
@@ -1,13 +1,10 @@
 import os
-import tempfile
 
 from ..hub.content.card import ReadmeMetadata, AirtableMetadata, RepoMetadataFile
 from ..utils.terminal import run_command
 from ..utils.logging import make_temp_dir
 from .. import ErsiliaBase
-
-from ..default import GITHUB_ORG
-
+from ..default import GITHUB_ORG, METADATA_JSON_FILE
 
 class ReadmeUpdater(ErsiliaBase):
     def __init__(self, model_id=None, repo_path=None, commit=True, config_json=None):
@@ -91,7 +88,7 @@ class JsonUpdater(ErsiliaBase):
         self._git_clone()
         ai = AirtableMetadata(model_id=self.model_id)
         data = ai.read_information()
-        tmp_file = os.path.join(self.tmp_folder, self.model_id, "metadata.json")
+        tmp_file = os.path.join(self.tmp_folder, self.model_id, METADATA_JSON_FILE)
         rm = RepoMetadataFile(model_id=self.model_id)
         rm.write_information(data, tmp_file)
         self._git_push()

--- a/ersilia/utils/paths.py
+++ b/ersilia/utils/paths.py
@@ -1,10 +1,11 @@
 import re
 import os
-import collections
+import json
+import yaml
 from pathlib import Path
 from ersilia import logger
 from .docker import resolve_pack_method_docker
-from ..default import PACK_METHOD_BENTOML, PACK_METHOD_FASTAPI
+from ..default import PACK_METHOD_BENTOML, PACK_METHOD_FASTAPI, METADATA_JSON_FILE, METADATA_YAML_FILE
 
 MODELS_DEVEL_DIRNAME = "models"
 
@@ -75,3 +76,16 @@ def resolve_pack_method(model_path):
         return resolve_pack_method_docker(model_id)
     else:
         return resolve_pack_method_source(model_path)
+    
+
+def get_metadata_from_base_dir(path):
+    if os.path.exists(os.path.join(path, METADATA_JSON_FILE)):
+        with open(os.path.join(path, METADATA_JSON_FILE), "r") as f:
+            metadata = json.load(f)
+    elif os.path.exists(os.path.join(path, METADATA_YAML_FILE)):
+        with open(os.path.join(path, METADATA_YAML_FILE), "r") as f:
+            metadata = yaml.safe_load(f)
+    else:
+        raise FileNotFoundError("Metadata file not found")
+    return metadata
+


### PR DESCRIPTION
This PR does a couple of things, but the main goal is build compatibility with Ersilia Pack's metadata storage format.

1. Reading metadata within ersilia is now agnostic of which format the metadata file follows, ie whether it is a JSON file or a YAML file (following the new template)
2. I've implemented a custom loader class for parsing the YAML file so it always loads the metadata in the data structure that is expected throughout ersilia. 
3. Parts of the code that tried to read metadata from the metadata file now use a util function, `get_metadata_from_base_dir`, found in `utils/paths` to get the metadata. This method looks for either the JSON or the YAML file and if neither is found, raises a `FileNotFoundError`.