### PR TITLE
Make fetch fail if standardrun doesnt work

### DIFF
--- a/ersilia/cli/commands/fetch.py
+++ b/ersilia/cli/commands/fetch.py
@@ -12,7 +12,8 @@ def fetch_cmd():
     """Create fetch commmand"""
 
     def _fetch(mf, model_id):
-        asyncio.run(mf.fetch(model_id))
+        res = asyncio.run(mf.fetch(model_id))
+        return res
 
     # Example usage: ersilia fetch {MODEL}
     @ersilia_cli.command(
@@ -118,5 +119,9 @@ def fetch_cmd():
             hosted_url=from_url,
             local_dir=from_dir,
         )
-        _fetch(mf, model_id)
-        echo(":thumbs_up: Model {0} fetched successfully!".format(model_id), fg="green")
+        is_fetched = _fetch(mf, model_id)
+
+        if is_fetched:
+            echo(":thumbs_up: Model {0} fetched successfully!".format(model_id), fg="green")
+        else:
+            echo(":thumbs_down: Model {0} failed to fetch!".format(model_id), fg="red")

--- a/ersilia/core/modelbase.py
+++ b/ersilia/core/modelbase.py
@@ -14,7 +14,7 @@ from .. import throw_ersilia_exception
 class ModelBase(ErsiliaBase):
     """Base class of a Model."""
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def __init__(self, model_id_or_slug=None, repo_path=None, config_json=None):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         if model_id_or_slug is None and repo_path is None:

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -430,7 +430,7 @@ class RunTracker(ErsiliaBase):
             for r in tabular_result:
                 writer.writerow(r)
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def track(self, input, result, meta, container_metrics):
         """
         Tracks the results of a model run.

--- a/ersilia/db/hubdata/sanitize.py
+++ b/ersilia/db/hubdata/sanitize.py
@@ -14,7 +14,7 @@ class AirtableSanitizer(ErsiliaBase):
         self.ai = AirtableInterface(config_json=self.config_json)
         self.HOSTED_URL_FIELD = "Host URL"
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_hosted_urls(self):
         for record in self.ai.items_all():
             fields = record["fields"]

--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -259,7 +259,7 @@ class ModelRepositoryGetter(BaseAction):
             else:
                 self.logger.debug("Example file {0} does not exist".format(file_name))
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def get(self):
         """Copy model repository from local or download from S3 or GitHub"""
         folder = self._model_path(self.model_id)
@@ -308,7 +308,7 @@ class ModelParametersGetter(BaseAction):
         model_path = self._model_path(self.model_id)
         return os.path.join(model_path, MODEL_DIR)
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def get(self):
         """Create a ./model folder in the model repository"""
         model_path = self._model_path(self.model_id)
@@ -350,7 +350,7 @@ class ModelGetter(BaseAction):
     def _get_model_parameters(self):
         self.mpg.get()
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def get(self):
         self.logger.debug("Getting repository")
         self._get_repository()

--- a/ersilia/hub/fetch/actions/prepare.py
+++ b/ersilia/hub/fetch/actions/prepare.py
@@ -17,7 +17,7 @@ class ModelPreparer(BaseAction):
             config_json=self.config_json, overwrite=self.overwrite
         )
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def prepare(self):
         try:
             self.deleter.delete(self.model_id)

--- a/ersilia/hub/fetch/actions/sniff_bentoml.py
+++ b/ersilia/hub/fetch/actions/sniff_bentoml.py
@@ -118,7 +118,7 @@ class ModelSniffer(BaseAction):
             return
         return md["Output Shape"]  # TODO Account for mixed types
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def _get_schema(self, results):
         input_schema = collections.defaultdict(list)
         output_schema = collections.defaultdict(list)
@@ -199,7 +199,7 @@ class ModelSniffer(BaseAction):
         self.logger.debug("Done with the schema!")
         return schema
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def _get_schema_type_for_simple_run_api_case(self):
         # read metadata
         dest_dir = self._model_path(self.model_id)
@@ -249,7 +249,7 @@ class ModelSniffer(BaseAction):
                 return shape
         return None
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def sniff(self):
         self.logger.debug("Sniffing model")
         self.logger.debug("Getting model size")

--- a/ersilia/hub/fetch/actions/sniff_fastapi.py
+++ b/ersilia/hub/fetch/actions/sniff_fastapi.py
@@ -74,7 +74,7 @@ class ModelSniffer(BaseAction):
         mbytes = size / (1024**2)
         return mbytes
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def sniff(self):
         self.logger.debug("Sniffing model")
         self.logger.debug("Getting model size")

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -240,6 +240,18 @@ class ModelFetcher(ErsiliaBase):
         self._fetch_not_from_dockerhub(model_id=model_id)
 
     async def fetch(self, model_id):
+        """Fetches a model with the given eos identifier
+
+        Parameters
+        ----------
+        model_id : str
+            The eos identifier of the model
+
+        Returns
+        -------
+        bool
+            True if the model was fetched successfully, False otherwise
+        """
         await self._fetch(model_id)
         try:  
             self._standard_csv_example(model_id)
@@ -251,6 +263,7 @@ class ModelFetcher(ErsiliaBase):
             if do_delete:
                 md = ModelFullDeleter(overwrite=False)
                 md.delete(model_id)
+            return False
         else:
             self.logger.debug("Writing model source to file")
             model_source_file = os.path.join(self._model_path(model_id), MODEL_SOURCE_FILE)
@@ -260,3 +273,4 @@ class ModelFetcher(ErsiliaBase):
                 self.logger.error(f"Error during folder creation: {error}")
             with open(model_source_file, "w") as f:
                 f.write(self.model_source)
+            return True

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -134,7 +134,7 @@ class ModelDockerHubFetcher(ErsiliaBase):
         with open(information_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     async def fetch(self, model_id):
         mp = ModelPuller(model_id=model_id, config_json=self.config_json)
         self.logger.debug("Pulling model image from DockerHub")

--- a/ersilia/hub/fetch/pack/bentoml_pack/runners.py
+++ b/ersilia/hub/fetch/pack/bentoml_pack/runners.py
@@ -149,7 +149,7 @@ class CondaPack(BasePack):
         self.logger.debug("Now trying to establish symlinks")
         self._symlinks()
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def run(self):
         self.logger.debug("Packing model with Conda")
         self._write_model_install_commands()

--- a/ersilia/hub/fetch/pack/fastapi_pack/runners.py
+++ b/ersilia/hub/fetch/pack/fastapi_pack/runners.py
@@ -102,7 +102,7 @@ class CondaPack(BasePack):
         self._symlinks()
         self.logger.debug("Symlinks created")
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def run(self):
         self.logger.debug("Packing model with Conda")
         self._run()

--- a/ersilia/hub/fetch/register/register.py
+++ b/ersilia/hub/fetch/register/register.py
@@ -74,7 +74,7 @@ class ModelRegisterer(ErsiliaBase):
         else:
             return None
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def register_from_hosted(self, url=None):
         if url is None:
             url = self._resolve_url()

--- a/ersilia/hub/fetch/register/standard_example.py
+++ b/ersilia/hub/fetch/register/standard_example.py
@@ -18,7 +18,7 @@ class ModelStandardExample(ErsiliaBase):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
         self.model_id = model_id
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception(exit=False)
     def _check_file_exists(self, output_csv):
         if not os.path.exists(output_csv):
             raise StandardModelExampleError(

--- a/ersilia/hub/pull/pull.py
+++ b/ersilia/hub/pull/pull.py
@@ -85,7 +85,7 @@ class ModelPuller(ErsiliaBase):
             self.logger.warning("Image not found locally")
             return None
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     async def async_pull(self):
         if self.is_available_locally():
             if self.overwrite is None:
@@ -186,7 +186,7 @@ class ModelPuller(ErsiliaBase):
             self.logger.info("Image {0} is not available".format(self.image_name))
             raise DockerImageNotAvailableError(model=self.model_id)
         
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def pull(self):
         if self.is_available_locally():
             if self.overwrite is None:

--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -198,7 +198,7 @@ class ExampleGenerator(ErsiliaBase):
         if type(self.input_shape) is InputShapePairOfLists:
             self._flatten = self._flatten_pair_of_lists
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_model_id(self, model_id):
         if model_id is None:
             raise NullModelIdentifierError(model=model_id)

--- a/ersilia/publish/test.py
+++ b/ersilia/publish/test.py
@@ -289,7 +289,7 @@ class ModelTester(ErsiliaBase):
     - Checks that the model output, output type, output shape is valid
     """
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_information(self, output):
 
 
@@ -322,7 +322,7 @@ class ModelTester(ErsiliaBase):
     Runs the model on a single smiles string and prints to the user if no output is specified.
     """
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_single_input(self, output):
         session = Session(config_json=None)
         service_class = session.current_service_class()
@@ -343,7 +343,7 @@ class ModelTester(ErsiliaBase):
     to the consol if no output file is specified by the user.
     """
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_example_input(self, output):
         session = Session(config_json=None)
         service_class = session.current_service_class()
@@ -375,7 +375,7 @@ class ModelTester(ErsiliaBase):
     
     
     
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def check_consistent_output(self):
         def compute_rmse(y_true, y_pred):
             squared_errors = [(yt - yp) ** 2 for yt, yp in zip(y_true, y_pred)]
@@ -575,7 +575,7 @@ class ModelTester(ErsiliaBase):
         return env_dir
     
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def get_directories_sizes(self):
         self.logger.debug(BOLD + "Calculating model size... " + RESET)
         def log_file_analysis(size, file_types, file_sizes, label):
@@ -620,7 +620,7 @@ class ModelTester(ErsiliaBase):
     }
     
     
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def run_bash(self):
         def updated_read_csv(self, file_path, ersilia_flag = False):
             data = []

--- a/ersilia/serve/services.py
+++ b/ersilia/serve/services.py
@@ -534,7 +534,7 @@ class DockerImageService(BaseServing):
                 return env
         return None
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def _is_docker_active(self):
         dr = DockerRequirement()
         if not dr.is_active():
@@ -673,7 +673,7 @@ class PulledDockerImageService(BaseServing):
     def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def _is_docker_active(self):
         dr = DockerRequirement()
         if not dr.is_active():
@@ -732,7 +732,7 @@ class PulledDockerImageService(BaseServing):
                 container.remove()
                 self.logger.debug("Container removed")
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def _get_apis(self):
         file_name = os.path.join(
             self._get_bundle_location(self.model_id), APIS_LIST_FILE

--- a/ersilia/setup/requirements/eospath.py
+++ b/ersilia/setup/requirements/eospath.py
@@ -8,7 +8,7 @@ class EosHomePathRequirement(object):
     def __init__(self):
         pass
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def eos_home_path_exists(self):
         if os.path.exists(EOS):
             return True

--- a/ersilia/setup/requirements/git.py
+++ b/ersilia/setup/requirements/git.py
@@ -10,7 +10,7 @@ class GithubCliRequirement(object):
     def __ini__(self):
         self.name = "gh"
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def is_installed(self, raise_exception=False, install_if_necessary=False):
         check = run_command_check_output("gh")
         if "GitHub" in check:
@@ -32,7 +32,7 @@ class GitLfsRequirement(object):
     def __init__(self):
         self.name = "git-lfs"
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def is_installed(self, install_if_necessary=True):
         check = run_command_check_output("git-lfs")
         if check.startswith("git-lfs"):

--- a/ersilia/setup/requirements/ping.py
+++ b/ersilia/setup/requirements/ping.py
@@ -7,7 +7,7 @@ class PingRequirement(object):
     def __init__(self):
         pass
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def is_connected(self):
         url = "http://www.google.com/"
         try:

--- a/ersilia/utils/conda.py
+++ b/ersilia/utils/conda.py
@@ -388,7 +388,7 @@ class SimpleConda(CondaUtils):
             f.write(bash_script)
         return file_name
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def run_commandlines(self, environment, commandlines):
         """
         Run commands in a given conda environment.

--- a/ersilia/utils/exceptions_utils/throw_ersilia_exception.py
+++ b/ersilia/utils/exceptions_utils/throw_ersilia_exception.py
@@ -18,40 +18,44 @@ def echo(text: str, **styles):
     return click.echo(click.style(text, **styles))
 
 
-def throw_ersilia_exception(func):
-    def inner_function(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as E:
-            text = ":police_car_light::police_car_light::police_car_light: Something went wrong with Ersilia :police_car_light::police_car_light::police_car_light:\n"
-            echo(text, blink=False, bold=True, fg="red")
-            echo("Error message:\n", fg="red", bold=True)
-            echo(str(E), fg="red")
-            text = "If this error message is not helpful, open an issue at:\n"
-            text += " - https://github.com/ersilia-os/ersilia\n"
-            text += "Or feel free to reach out to us at:\n"
-            text += " - hello[at]ersilia.io\n\n"
-            text += "If you haven't, try to run your command in verbose mode (-v in the CLI)\n"
-            text += " - You will find the console log file in: {0}/{1}".format(
-                EOS, CURRENT_LOGGING_FILE
-            )
-            echo(text, fg="green")
-
-            sys.exit(DEFAULT_ERSILIA_ERROR_EXIT_CODE)  # TODO Enable automatic reporting
-            if query_yes_no("Would you like to report this error to Ersilia?"):
-                if query_yes_no(
-                    "Would you like to include your last Ersilia command in the issue (for issue reproducibility)?"
-                ):
-                    sys.stdout.write("Please re-type your last Ersilia command: ")
-                    message = input()
-                    send_exception_issue(E, message)
+def throw_ersilia_exception(exit=True):
+    # Ref: https://stackoverflow.com/a/5929165
+    def _throw_ersilia_exception(func):
+        def inner_function(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as error:
+                text = ":police_car_light::police_car_light::police_car_light: Something went wrong with Ersilia :police_car_light::police_car_light::police_car_light:\n"
+                echo(text, blink=False, bold=True, fg="red")
+                echo("Error message:\n", fg="red", bold=True)
+                echo(str(error), fg="red")
+                text = "If this error message is not helpful, open an issue at:\n"
+                text += " - https://github.com/ersilia-os/ersilia\n"
+                text += "Or feel free to reach out to us at:\n"
+                text += " - hello[at]ersilia.io\n\n"
+                text += "If you haven't, try to run your command in verbose mode (-v in the CLI)\n"
+                text += " - You will find the console log file in: {0}/{1}".format(
+                    EOS, CURRENT_LOGGING_FILE
+                )
+                echo(text, fg="green")
+                if exit:
+                    sys.exit(DEFAULT_ERSILIA_ERROR_EXIT_CODE)
                 else:
-                    send_exception_issue(E, "")
+                    raise error
+                # FIXME: Enable automatic reporting of issues
+                # if query_yes_no("Would you like to report this error to Ersilia?"):
+                #     if query_yes_no(
+                #         "Would you like to include your last Ersilia command in the issue (for issue reproducibility)?"
+                #     ):
+                #         sys.stdout.write("Please re-type your last Ersilia command: ")
+                #         message = input()
+                #         send_exception_issue(E, message)
+                #     else:
+                #         send_exception_issue(E, "")
 
-            # if query_yes_no("Would you like to access the log?"):
-            #     print("No log info")
-            #     # TODO: execute cli logic for [y/n] query and write log to a file
+                # if query_yes_no("Would you like to access the log?"):
+                #     print("No log info")
+                #     # TODO: execute cli logic for [y/n] query and write log to a file
 
-            sys.exit()
-
-    return inner_function
+        return inner_function    
+    return _throw_ersilia_exception

--- a/ersilia/utils/tracking.py
+++ b/ersilia/utils/tracking.py
@@ -39,7 +39,7 @@ RUN_DATA_STUB = {  # This should not be used as is, always create a deep copy.
     "error_count": 0
 }
 
-@throw_ersilia_exception
+@throw_ersilia_exception()
 def init_tracking_summary(model_id):
     file_path = os.path.join(get_session_dir(), f"{get_session_uuid()}.json")
     try:
@@ -51,7 +51,7 @@ def init_tracking_summary(model_id):
         raise FileNotFoundError("Could not create tracking summary file, check if session directory exists")
 
 
-@throw_ersilia_exception
+@throw_ersilia_exception()
 def update_tracking_summary(model_id, incoming_data):
     try:
         file_path = os.path.join(get_session_dir(), f"{get_session_uuid()}.json")

--- a/ersilia/utils/venv.py
+++ b/ersilia/utils/venv.py
@@ -29,7 +29,7 @@ class SimpleVenv(ErsiliaBase):
         else:
             return False
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def create(self, environment):
         path = self._get_path(environment)
         if self.exists(path):
@@ -44,7 +44,7 @@ class SimpleVenv(ErsiliaBase):
             return
         shutil.rmtree(path)
 
-    @throw_ersilia_exception
+    @throw_ersilia_exception()
     def run_commandlines(self, environment, commandlines):
         if not self.exists(environment):
             raise Exception("{0} environment does not exist".format(environment))


### PR DESCRIPTION
Logs below:
```bash
00:16:09 | DEBUG    | Activation done
00:16:09 | DEBUG    | Packing command successfully run inside eos8ub5 conda environment
00:16:09 | DEBUG    | Creating model symlink bundle > dest
00:16:09 | DEBUG    | Creating symlink from /home/dee/eos/repository/eos8ub5/20241119-9eadd098-3169-4cac-8e85-697055a510a0/model
00:16:09 | DEBUG    | Creating symlink to /home/dee/eos/dest/eos8ub5/model
00:16:09 | INFO     | Could not create symbolic link from /home/dee/eos/dest/eos8ub5/data.h5 to /home/dee/eos/isaura/lake/eos8ub5_public.h5
00:16:09 | DEBUG    | Symlinks created
00:16:09 | DEBUG    | Getting model card of eos8ub5
00:16:09 | DEBUG    | Trying to get metadata from: /home/dee/eos/dest/eos8ub5
00:16:09 | DEBUG    | Card saved at /home/dee/eos/dest/eos8ub5/card.json
00:16:09 | DEBUG    | Saving slug chemical-space-projections-coconut
00:16:09 | DEBUG    | Checking that autoservice works
00:16:09 | DEBUG    | Setting BentoML AutoService for eos8ub5
00:16:09 | DEBUG    | No service class provided, deciding automatically
00:16:09 | DEBUG    | No service class file exists in /home/dee/eos/repository/eos8ub5/20241119-9eadd098-3169-4cac-8e85-697055a510a0/service_class.txt
00:16:09 | DEBUG    | Pack method is: fastapi
00:16:09 | DEBUG    | Pack method is: fastapi
00:16:09 | DEBUG    | Setting virtual environment at /home/dee/eos/dest/eos8ub5
00:16:09 | DEBUG    | Pack method is: fastapi
00:16:10 | DEBUG    | Pack method is: fastapi
00:16:10 | DEBUG    | Service class: conda
00:16:10 | DEBUG    | Getting APIs from list file
00:16:10 | DEBUG    | Getting APIs from FastAPI
00:16:10 | DEBUG    | Sniffing model
00:16:10 | DEBUG    | Getting model size
00:16:10 | DEBUG    | Model size is 4736.359976768494 MB
00:16:10 | DEBUG    | Fetching eos8ub5 done in time: 0:00:28.725089s
00:16:10 | INFO     | Fetching eos8ub5 done successfully: 0:00:28.725089
00:16:10 | DEBUG    | Running standard CSV example
00:16:10 | DEBUG    | /home/dee/eos/dest/eos8ub5/example_standard_input.csv
00:16:10 | DEBUG    | /home/dee/eos/dest/eos8ub5/example_standard_output.csv
00:16:10 | DEBUG    | Usage: ersilia [OPTIONS] COMMAND [ARGS]...

  🦠 Welcome to Ersilia! 💊

Options:
  --version      Show the version and exit.
  -v, --verbose  Show logging on terminal when running commands.
  -s, --silent   Do not echo any progress message.
  --help         Show this message and exit.

Commands:
  auth       Log in to ersilia to enter contributor mode.
  catalog    List a catalog of models
  close      Close model
  delete     Delete model from local computer
  example    Generate input examples for the model of interest
  fetch      Fetch model from Ersilia Model Hub
  info       Get model information
  inspect    Inspect model
  run        Run a served model
  sample     Sample inputs and model identifiers
  serve      Serve model
  test       Test a model
  uninstall  Uninstall ersilia

00:16:10 | DEBUG    | No need to use Conda!
🚀 Serving model eos8ub5: chemical-space-projections-coconut

   URL: http://0.0.0.0:55307
   PID: 59444
   SRV: conda
   Output source: local-only

👉 To run model:
   - run

💁 Information:
   - info
00:16:15 | ERROR    | Ersilia exception class:
StandardModelExampleError

Detailed error:
Standard model run from CSV was not possible for model eos8ub5
Output file /home/dee/eos/dest/eos8ub5/example_standard_output.csv was not created successfully

Hints:
If you fetch this model from Docker Hub, or you are running it through URL, this is the first time run is executed in your local computer. Reach out to Ersilia to get specific help.

🚨🚨🚨 Something went wrong with Ersilia 🚨🚨🚨

Error message:

Ersilia exception class:
StandardModelExampleError

Detailed error:
Standard model run from CSV was not possible for model eos8ub5
Output file /home/dee/eos/dest/eos8ub5/example_standard_output.csv was not created successfully

Hints:
If you fetch this model from Docker Hub, or you are running it through URL, this is the first time run is executed in your local computer. Reach out to Ersilia to get specific help.

If this error message is not helpful, open an issue at:
 - https://github.com/ersilia-os/ersilia
Or feel free to reach out to us at:
 - hello[at]ersilia.io

If you haven't, try to run your command in verbose mode (-v in the CLI)
 - You will find the console log file in: /home/dee/eos/current.log
00:16:15 | DEBUG    | Standard model example failed, deleting artifacts
Do you want to delete the model artifacts? [Y/n]
00:16:20 | INFO     | Starting delete of model eos8ub5
00:16:20 | INFO     | Removing EOS folder /home/dee/eos/dest/eos8ub5
00:16:21 | INFO     | Removing bundle folder /home/dee/eos/repository/eos8ub5
00:16:21 | DEBUG    | Folder removed
00:16:21 | DEBUG    | Attempting Bento delete
00:16:21 | DEBUG    | Attempting temporary folder delete
00:16:21 | DEBUG    | Attempting lake delete (local)
00:16:21 | DEBUG    | Deleting /home/dee/eos/isaura/lake/eos8ub5_local.h5
00:16:21 | DEBUG    | Attempting lake delete (public)
00:16:21 | DEBUG    | Deleting /home/dee/eos/isaura/lake/eos8ub5_public.h5
00:16:22 | INFO     | Removing docker images and stopping containers related to eos8ub5
Total reclaimed space: 0B
00:16:22 | DEBUG    | Running docker images > /tmp/ersilia-jasxcrf1/docker-images.txt
00:16:22 | DEBUG    | Model entry eos8ub5 was not available in the fetched models registry
00:16:22 | SUCCESS  | Model eos8ub5 deleted successfully
👎 Model eos8ub5 failed to fetch!
```

This PR attempts to fix the issue where ersilia behaves as if a given model got fetched successfully even if the Standard Example run for that model failed. This behavior has downstream effects in terms of making ersilia catalog pick up this model among locally available models. Because these model artifacts remain present on the system, the model can also be served. Through this PR, if the standard run fails, we delete all model artifacts, ie the model dest and model bundle, thereby remaining true to the fact that the model fetching failed.