### PR TITLE
Remove setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ docker = "^7.1.0"
 boto3 = "^1.28.40"
 requests = "^2.31.0"
 numpy = "<=1.26.4"
-setuptools = "^70.0.0"                                      #  added to fix the issue with setuptools
 aiofiles = "<=24.1.0"
 aiohttp = ">=3.10.11"
 nest_asyncio = "<=1.6.0"


### PR DESCRIPTION
Unnecessary dependency inclusion for something that is already in Python's site packages.