### PR TITLE
Generalize Standard Run 

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -24,17 +24,11 @@ def run_cmd():
         "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
     )
     @click.option(
-        "--standard",
-        is_flag=True,
-        default=True,
-        help="Assume that the run is standard and, therefore, do not do so many checks.",
-    ) # TODO this should go away
-    @click.option(
         "--table", 
         is_flag=True, 
         default=False
     )
-    def run(input, output, batch_size, table, standard): # TODO standard should go away
+    def run(input, output, batch_size, table):
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
@@ -60,7 +54,6 @@ def run_cmd():
             output=output,
             batch_size=batch_size,
             track_run=track_runs,
-            try_standard=standard, # TODO this should go away
         )
         if isinstance(result, types.GeneratorType):
             for result in mdl.run(input=input, output=output, batch_size=batch_size):

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -28,13 +28,13 @@ def run_cmd():
         is_flag=True,
         default=True,
         help="Assume that the run is standard and, therefore, do not do so many checks.",
-    )
+    ) # TODO this should go away
     @click.option(
         "--table", 
         is_flag=True, 
         default=False
     )
-    def run(input, output, batch_size, table, standard):
+    def run(input, output, batch_size, table, standard): # TODO standard should go away
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
@@ -60,7 +60,7 @@ def run_cmd():
             output=output,
             batch_size=batch_size,
             track_run=track_runs,
-            try_standard=standard,
+            try_standard=standard, # TODO this should go away
         )
         if isinstance(result, types.GeneratorType):
             for result in mdl.run(input=input, output=output, batch_size=batch_size):

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -488,7 +488,6 @@ class ErsiliaModel(ErsiliaBase):
         output=None,
         batch_size=DEFAULT_BATCH_SIZE,
         track_run=False,
-        try_standard=True, # TODO This should go away
     ):
         # TODO this should be smart enough to init the container sampler
         # or a python process sampler based on how the model was fetched
@@ -501,19 +500,18 @@ class ErsiliaModel(ErsiliaBase):
 
         # TODO The logic should be in a try except else finally block
         standard_status_ok = False
-        if try_standard: # TODO This should go away
-            self.logger.debug("Trying standard API")
-            try:
-                result, standard_status_ok = self._standard_run(
-                    input=input, output=output
-                )
-            except Exception as e:
-                self.logger.warning(
-                    "Standard run did not work with exception {0}".format(e)
-                )
-                result = None
-                standard_status_ok = False
-                self.logger.debug("We will try conventional run.")
+        self.logger.debug("Trying standard API")
+        try:
+            result, standard_status_ok = self._standard_run(
+                input=input, output=output
+            )
+        except Exception as e:
+            self.logger.warning(
+                "Standard run did not work with exception {0}".format(e)
+            )
+            result = None
+            standard_status_ok = False
+            self.logger.debug("We will try conventional run.")
         if standard_status_ok: # TODO This should be an else block
             return result
         else:

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -354,7 +354,7 @@ class ErsiliaModel(ErsiliaBase):
         return True
 
     def _do_cache_splits(self, input, output):
-        self.tfr = None # TODO Set in __init__
+        self.tfr = None
         if self._evaluate_do_cache_splits(input, output):
             self.tfr = TabularFileReader(
                 path=input,

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -3,7 +3,6 @@ import csv
 import json
 import time
 import types
-import tempfile
 import asyncio
 import importlib
 import collections
@@ -12,7 +11,6 @@ import __main__ as main
 from .. import logger
 from ..serve.api import Api
 from .session import Session
-from datetime import datetime
 from .base import ErsiliaBase
 from ..lake.base import LakeBase
 from ..utils import tmp_pid_file
@@ -280,11 +278,6 @@ class ErsiliaModel(ErsiliaBase):
 
     def _standard_api_runner(self, input, output):
         scra = StandardCSVRunApi(model_id=self.model_id, url=self._get_url())
-        if not scra.is_ready():
-            self.logger.debug(
-                "Standard CSV Api runner is not ready for this particular model"
-            )
-            return None
         if not scra.is_amenable(output):
             self.logger.debug(
                 "Standard CSV Api runner is not amenable for this model, input and output"
@@ -326,6 +319,7 @@ class ErsiliaModel(ErsiliaBase):
             return True
         return False
 
+    # TODO should use the throw_ersilia_exception decorator
     def _get_api_runner(self, output):
         if output is None:
             use_iter = True
@@ -360,7 +354,7 @@ class ErsiliaModel(ErsiliaBase):
         return True
 
     def _do_cache_splits(self, input, output):
-        self.tfr = None
+        self.tfr = None # TODO Set in __init__
         if self._evaluate_do_cache_splits(input, output):
             self.tfr = TabularFileReader(
                 path=input,
@@ -480,13 +474,13 @@ class ErsiliaModel(ErsiliaBase):
         t1 = None
         status_ok = False
         result = self._standard_api_runner(input=input, output=output)
-        if type(output) is str:
+        if type(output) is str: # TODO Redundant, should be removed
             if os.path.exists(output):
                 t1 = os.path.getctime(output)
         if t1 is not None:
-            if t1 > t0:
+            if t1 > t0: # TODO Why would this be less?
                 status_ok = True
-        return result, status_ok
+        return result, status_ok # TODO This doesn't actually check whether the result exists and isn't null
 
     def run(
         self,
@@ -494,7 +488,7 @@ class ErsiliaModel(ErsiliaBase):
         output=None,
         batch_size=DEFAULT_BATCH_SIZE,
         track_run=False,
-        try_standard=True,
+        try_standard=True, # TODO This should go away
     ):
         # TODO this should be smart enough to init the container sampler
         # or a python process sampler based on how the model was fetched
@@ -504,8 +498,10 @@ class ErsiliaModel(ErsiliaBase):
         if self.ct_tracker and track_run:
             self.ct_tracker.start_tracking()
         self.logger.info("Starting runner")
+
+        # TODO The logic should be in a try except else finally block
         standard_status_ok = False
-        if try_standard:
+        if try_standard: # TODO This should go away
             self.logger.debug("Trying standard API")
             try:
                 result, standard_status_ok = self._standard_run(
@@ -518,7 +514,7 @@ class ErsiliaModel(ErsiliaBase):
                 result = None
                 standard_status_ok = False
                 self.logger.debug("We will try conventional run.")
-        if standard_status_ok:
+        if standard_status_ok: # TODO This should be an else block
             return result
         else:
             self.logger.debug("Trying conventional run")

--- a/ersilia/io/readers/file.py
+++ b/ersilia/io/readers/file.py
@@ -196,7 +196,6 @@ class BaseTabularFile(object):
                             self.matching
                         )
                     )
-                    return self.matching
                 if i > self.sniff_line_limit:
                     self.logger.debug("Stopping sniffer for resolving column types")
                     break
@@ -266,7 +265,6 @@ class BaseTabularFile(object):
         if key is not None and input is not None:
             assert len(key) == len(input)
         self.matching = {"input": input, "key": key}
-        return self.matching
 
     def has_header(self):
         if self._has_header is not None:

--- a/ersilia/serve/standard_api.py
+++ b/ersilia/serve/standard_api.py
@@ -93,42 +93,6 @@ class StandardCSVRunApi(ErsiliaBase):
                     return True
         return False
 
-    def is_input_standard_csv_file(self, input_data): #TODO Not really used anywhere.
-        if type(input_data) != str:
-            return False
-        if not input_data.endswith(".csv"):
-            return False
-        if not os.path.exists(input_data):
-            return False
-        if self._is_input_file_too_long(input_data):
-            return False
-        with open(input_data, "r") as f:
-            reader = csv.reader(f)
-            header = next(reader)
-        if len(header) == 1:
-            h = header[0].lower()
-            if not self.encoder.is_input_header(h):
-                return False
-            else:
-                return True
-        elif len(header) == 2:
-            h0 = header[0].lower()
-            h1 = header[1].lower()
-            if not self.encoder.is_key_header(h0):
-                return False
-            if not self.encoder.is_input_header(h1):
-                return False
-            return True
-        elif len(header) == 3:
-            h0 = header[0].lower()
-            h1 = header[1].lower()
-            if not self.encoder.is_key_header(h0):
-                return False
-            if not self.encoder.is_input_header(h1):
-                return False
-            return True
-        else:
-            return False
 
     def is_input_type_standardizable(self):
         if self.input_type and self.input_shape:
@@ -310,8 +274,3 @@ class StandardCSVRunApi(ErsiliaBase):
             return output_data
         else:
             return None
-
-class StandardQueryApi(object):
-    def __init__(self, model_id, url):
-        # TODO This class will be used to query directly the calculations lake.
-        pass

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -64,7 +64,7 @@ def mock_get_url():
 def mock_get_input():
     with patch.object(
         StandardCSVRunApi, 
-        "get_input_type",
+        "_read_field_from_metadata",
           return_value=["Compound"]
     ) as mock_input_type:
         yield mock_input_type
@@ -78,17 +78,6 @@ def mock_std_header():
         return_value=HEADER
     ) as mock_method:
         yield mock_method
-
-
-@pytest.fixture
-def mock_is_ready():
-    with patch.object(
-        StandardCSVRunApi, 
-        "is_ready", 
-        return_value=True
-    ) as mock_is_ready:
-        yield mock_is_ready
-
 
 @pytest.fixture
 def mock_is_amenable():
@@ -170,7 +159,6 @@ def test_standard_api_string(
     mock_fetcher,
     mock_set_apis,
     mock_get_input,
-    mock_is_ready,
     mock_std_header,
     mock_is_amenable,
     mock_get_url,
@@ -187,7 +175,6 @@ def test_standard_api_string(
     assert mock_get_url.called
     assert mock_get_input.called
     assert mock_std_header.called
-    assert mock_is_ready.called
     assert mock_is_amenable.called
     assert mock_std_api_post.called
 
@@ -200,7 +187,6 @@ def test_standard_api_csv(
     mock_fetcher,
     mock_set_apis,
     mock_get_input,
-    mock_is_ready,
     mock_std_header,
     mock_is_amenable,
     mock_get_url,
@@ -217,7 +203,6 @@ def test_standard_api_csv(
     assert mock_get_input.called
     assert mock_get_url.called
     assert mock_std_header.called
-    assert mock_is_ready.called
     assert mock_is_amenable.called
     assert mock_set_apis.called
     assert RESULT_CSV in result.output


### PR DESCRIPTION
The aim of this PR is to generalize standard run to work with any type of model server response and be able to serialize a CSV output file. In addition to that, other changes introduced through this PR are:

- We can now calculate the output csv header from a predefined example file, in addition to the standard csv output file
- The is_ready function from the StandardCSVRunApi class is removed, and only the is_amenable function is kept because the checks in the latter were a superset of the ones in is_ready.
- Unused code is removed
- The `run` method no longer has a try_standard parameter because standard run is the default behavior.