### PR TITLE
Refactor Catalog command

### DIFF
--- a/ersilia/cli/commands/catalog.py
+++ b/ersilia/cli/commands/catalog.py
@@ -66,7 +66,8 @@ def catalog_cmd():
         required=False,
     )
     @click.option(
-        "--as-table",
+        "-j/-t",
+        "--as-json/--as-table",
         is_flag=True,
         default=False,
         help="Show catalog in table format",
@@ -79,7 +80,7 @@ def catalog_cmd():
         more=False,
         card=False,
         model=None,
-        as_table=False,
+        as_json=False,
     ):
         if card and not model:
             click.echo(
@@ -143,9 +144,8 @@ def catalog_cmd():
                     )
                 )
                 return
-
         if file_name is None:
-            catalog = catalog_table.as_table() if as_table else catalog_table.as_json()
+            catalog = catalog_table.as_json() if as_json else catalog_table.as_table()
         else:
             catalog_table.write(file_name)
             catalog = None

--- a/ersilia/cli/commands/example.py
+++ b/ersilia/cli/commands/example.py
@@ -37,7 +37,6 @@ def example_cmd():
     def example():
         pass
 
-    
     @example.command()
     @click.argument("model", required=False, default=None, type=click.STRING)
     @click.option("--n_samples", "-n", default=5, type=click.INT)
@@ -50,6 +49,15 @@ def example_cmd():
         else:
             session = Session(config_json=None)
             model_id = session.current_model_id()
+            if model_id is None:
+                click.echo(
+                    click.style(
+                        "Error: No model id given and no model found running in this shell.",
+                        fg="red",
+                    ),
+                    err=True,
+                )
+                return
         eg = ExampleGenerator(model_id=model_id)
         if file_name is None:
             echo(
@@ -60,7 +68,6 @@ def example_cmd():
             )
         else:
             eg.example(n_samples, file_name, simple, try_predefined=predefined)
-
 
     @example.command()
     @click.option("--n_samples", "-n", default=5, type=click.INT)

--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -271,7 +271,7 @@ class ExampleGenerator(ErsiliaBase):
         if try_predefined is True and file_name is not None:
             self.logger.debug("Trying with predefined input")
             predefined_available = self.predefined_example(file_name)
-        
+
         if predefined_available:
             with open(file_name, "r") as f:
                 return f.read()

--- a/ersilia/utils/exceptions_utils/exceptions.py
+++ b/ersilia/utils/exceptions_utils/exceptions.py
@@ -93,7 +93,9 @@ class EmptyOutputError(ErsiliaError):
         output_file = os.path.join(framework_dir, "example_output.csv")
         tmp_folder = make_temp_dir(prefix="ersilia-")
         log_file = os.path.join(tmp_folder, "terminal.log")
-        run_command("ersilia example inputs {0} -n 3 -f {1}".format(self.model_id, input_file))
+        run_command(
+            "ersilia example inputs {0} -n 3 -f {1}".format(self.model_id, input_file)
+        )
         cmd = "bash {0} {1} {2} {3} 2>&1 | tee -a {4}".format(
             exec_file, framework_dir, input_file, output_file, log_file
         )


### PR DESCRIPTION
This PR introduces more changes to make the catalog command simpler:

- [x] Catalog command should show a table by default. Consolidate --as-table / --as-json option.
- [x] Catalog command should show the identifier and slug by default when the --more option is not used
- [x] Catalog --browser eliminate and consolidate --local/--hub
- [x] Harmonize the --more flag: Identifier, Slug, Title, Task, Input shape, Output, Output shape, Model source (if local)
- [x] Sort models by ID
- [x] Index in the table to know how many models are there