### PR TITLE
Fix thread holding when tracking

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -27,7 +27,7 @@ def run_cmd():
     .. code-block:: console
 
         Run a model by its ID with input data:
-        $ ersilia run -i <input_data> --table
+        $ ersilia run -i <input_data> --as-table
 
         Run a model with batch size:
         $ ersilia run -i <input_data> -b 50
@@ -41,8 +41,8 @@ def run_cmd():
     @click.option(
         "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
     )
-    @click.option("--table", is_flag=True, default=False)
-    def run(input, output, batch_size, table):
+    @click.option("--as-table", is_flag=True, default=False)
+    def run(input, output, batch_size, as_table):
         session = Session(config_json=None)
         model_id = session.current_model_id()
         service_class = session.current_service_class()
@@ -73,14 +73,14 @@ def run_cmd():
             for result in mdl.run(input=input, output=output, batch_size=batch_size):
                 if result is not None:
                     formatted = json.dumps(result, indent=4)
-                    if table:
+                    if as_table:
                         print_result_table(formatted)
                     else:
                         echo(formatted)
                 else:
                     echo("Something went wrong", fg="red")
         else:
-            if table:
+            if as_table:
                 print_result_table(result)
             else:
                 try:

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -772,9 +772,6 @@ class ErsiliaModel(ErsiliaBase):
         Any
             The result of the model run(such as output csv file name, json).
         """
-        # TODO this should be smart enough to init the container sampler
-        # or a python process sampler based on how the model was fetched
-        # Presently we only deal with containers
 
         # Init the container metrics sampler
         if self.ct_tracker and track_run:
@@ -793,17 +790,14 @@ class ErsiliaModel(ErsiliaBase):
             result = None
             standard_status_ok = False
             self.logger.debug("We will try conventional run.")
-        if standard_status_ok:  # TODO This should be an else block
-            return result
-        else:
+        
+        if not standard_status_ok:
             self.logger.debug("Trying conventional run")
-            self.logger.debug("Input: {0}".format(input))
-            self.logger.debug("Output: {0}".format(output))
-            self.logger.debug("Batch size: {0}".format(batch_size))
             result = self._run(
                 input=input, output=output, batch_size=batch_size, track_run=track_run
             )
-        # Start tracking model run if track flag is used in serve
+
+        # Collect metrics sampled during run if tracking is enabled
         if self._run_tracker and track_run:
             self.ct_tracker.stop_tracking()
             container_metrics = self.ct_tracker.get_average_metrics()


### PR DESCRIPTION
Don't preemptively return result as this keeps the tracking thread from stopping and holds the process continuously

