### PR TITLE
Pubchem smiles to inchikey negative

### DIFF
--- a/test/test_compound_identifier.py
+++ b/test/test_compound_identifier.py
@@ -188,3 +188,17 @@ async def test_nci_smiles_to_inchikey_negative(mock_get, compound_identifier):
         session=None, smiles="invalid_smiles"
     )
     assert inchikey is None
+
+
+@patch("requests.get")
+async def test_pubchem_smiles_to_inchikey_positive(mock_get, compound_identifier):
+    """Test _pubchem_smiles_to_inchikey with a mocked positive response."""
+    mock_response = mock_get.return_value
+    mock_response.status_code = 200
+    mock_response.text = "InChIKey=BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+
+    inchikey = await compound_identifier._pubchem_smiles_to_inchikey(
+        session=None, smiles="CCO"
+    )
+    assert inchikey == "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+

--- a/test/test_compound_identifier.py
+++ b/test/test_compound_identifier.py
@@ -202,3 +202,13 @@ async def test_pubchem_smiles_to_inchikey_positive(mock_get, compound_identifier
     )
     assert inchikey == "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
 
+@patch("requests.get")
+async def test_pubchem_smiles_to_inchikey_negative(mock_get, compound_identifier):
+    """Test _pubchem_smiles_to_inchikey with a mocked negative response."""
+    mock_response = mock_get.return_value
+    mock_response.status_code = 404
+
+    inchikey = await compound_identifier._pubchem_smiles_to_inchikey(
+        session=None, smiles="invalid_smiles"
+    )
+    assert inchikey is None


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

This commit will add a negative test for _pubchem_smiles_to_inchikey

**Changes to be made**

Added a new test function for _pubchem_smiles_to_inchikey negative test in test/test_compound_identifier.py

**Status**

- [x] Written test and validated logically using pytest

**To do**

_If this is a work in progress, Replace this line with your next steps_

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #1319