### PR TITLE
Raise error if model directory doesn't exist

### DIFF
--- a/ersilia/core/modelbase.py
+++ b/ersilia/core/modelbase.py
@@ -6,7 +6,6 @@ from ..hub.content.slug import Slug
 from ..hub.fetch import STATUS_FILE, DONE_TAG
 from ..default import IS_FETCHED_FROM_DOCKERHUB_FILE
 from ..utils.paths import get_metadata_from_base_dir
-
 from ..utils.exceptions_utils.exceptions import InvalidModelIdentifierError
 from .. import throw_ersilia_exception
 
@@ -47,8 +46,12 @@ class ModelBase(ErsiliaBase):
                 raise InvalidModelIdentifierError(model=self.text)
 
         if repo_path is not None:
-            self.logger.debug("Repo path specified: {0}".format(repo_path))
-            self.logger.debug("Absolute path: {0}".format(os.path.abspath(repo_path)))
+            self.logger.debug(f"Repo path specified: {repo_path}")
+            abspath = os.path.abspath(repo_path)
+            self.logger.debug(f"Absolute path: {abspath}")
+            # Check if path actually exists
+            if not os.path.exists(abspath):
+                raise FileNotFoundError("Model directory does not exist at the provided path. Please check the path and try again.")
             self.text = self._get_model_id_from_path(repo_path)
             self.model_id = self.text
             slug = self._get_slug_if_available(repo_path)


### PR DESCRIPTION
The fix includes raising an error when the model directory doesn't exist on the system.

Logs after the implemented fix:

```python
(ersilia) ☁  ersilia-project  ersilia -v fetch eos9iyc --from_dir ./eos9iyc
From dir:  ./eos9iyc
17:38:05 | DEBUG    | Repo path specified: ./eos9iyc
17:38:05 | DEBUG    | Absolute path: /home/user/ersilia-project/eos9iyc
🚨🚨🚨 Something went wrong with Ersilia 🚨🚨🚨

Error message:

Model directory does not exist at the provided path. Please check the path and try again.
If this error message is not helpful, open an issue at:
 - https://github.com/ersilia-os/ersilia
Or feel free to reach out to us at:
 - hello[at]ersilia.io

If you haven't, try to run your command in verbose mode (-v in the CLI)
 - You will find the console log file in: /home/user/eos/current.log
```


Closes #1458