### PR TITLE
Access the correct index to get model identifier when deleting all local models

### DIFF
--- a/ersilia/cli/commands/delete.py
+++ b/ersilia/cli/commands/delete.py
@@ -57,6 +57,7 @@ def delete_cmd():
         model_catalog = ModelCatalog()
         catalog_table = model_catalog.local()
         local_models = catalog_table.data if catalog_table else None
+        idx = catalog_table.columns.index("Identifier")
         if not local_models:
             echo(
                 ":person_tipping_hand: No models are available locally for deletion.",
@@ -65,11 +66,17 @@ def delete_cmd():
             return
         deleted_count = 0
         for model_row in local_models:
-            model_id = model_row[0]
-            if _delete_model_by_id(model_id):
+            model_id = model_row[idx]
+            try:
+                _delete_model_by_id(model_id)
                 deleted_count += 1
+            except Exception as e:
+                echo(
+                    f":warning: Error deleting model {model_id}: {e}",
+                    fg="red",
+                )
         echo(
-            ":thumbs_up: Completed the deletion of all locally available models!",
+            f":thumbs_up: Completed the deletion of {deleted_count} locally available models!",
             fg="green",
         )
 


### PR DESCRIPTION
Due to recent changes made in which data columns are stored in the [CatalogTable](https://github.com/ersilia-os/ersilia/pull/1426), it had a downstream effect on the delete functionality, wherein we first access the local catalog and read each line item in the catalog table, assuming that the first column in each row contains the model identifier. The PR removes this hard coding of the column index by first getting the correct column index and then using it to access the right field in the row.

Closes #1468 