### PR TITLE
Final CLI Improvements

### DIFF
--- a/ersilia/cli/commands/example.py
+++ b/ersilia/cli/commands/example.py
@@ -21,8 +21,8 @@ def example_cmd():
     @click.option("--n_samples", "-n", default=5, type=click.INT)
     @click.option("--file_name", "-f", default=None, type=click.STRING)
     @click.option("--simple/--complete", "-s/-c", default=True)
-    @click.option("--predefined/--random", "-p/-r", default=True)
-    def example(model, n_samples, file_name, simple, predefined):
+    @click.option("--random/--predefined", "-r/-p", default=True)
+    def example(model, n_samples, file_name, simple, random):
         if model is not None:
             model_id = ModelBase(model).model_id
         else:
@@ -38,9 +38,9 @@ def example_cmd():
         if file_name is None:
             echo(
                 json.dumps(
-                    eg.example(n_samples, file_name, simple, try_predefined=predefined),
+                    eg.example(n_samples, file_name, simple, try_predefined=not random),
                     indent=4,
                 )
             )
         else:
-            eg.example(n_samples, file_name, simple, try_predefined=predefined)
+            eg.example(n_samples, file_name, simple, try_predefined=not random)

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -41,7 +41,7 @@ def run_cmd():
     @click.option(
         "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
     )
-    @click.option("--as-table", is_flag=True, default=False)
+    @click.option("--as-table/-t", is_flag=True, default=False)
     def run(input, output, batch_size, as_table):
         session = Session(config_json=None)
         model_id = session.current_model_id()

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -299,7 +299,10 @@ class ModelCatalog(ErsiliaBase):
         idx = 0
         for card in model_cards:
             status = self._get_status(card)
+            slug = self._get_slug(card)
             if status == "In Progress":
+                continue
+            if "test" in slug:
                 continue
             idx += 1
             r = [idx]

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -191,12 +191,10 @@ class CatalogTable(object):
             The name of the file to write the catalog table to.
         """
         with open(file_name, "w") as f:
-            if file_name.endswith(".csv"):
-                delimiter = ","
-            elif file_name.endswith(".tsv"):
+            if file_name.endswith(".tsv"):
                 delimiter = "\t"
             else:
-                return None
+                delimiter = ","  # Default to CSV always
             writer = csv.writer(f, delimiter=delimiter)
             writer.writerow(self.columns)
             for r in self.data:

--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -5,6 +5,8 @@ import json
 import os
 import shutil
 
+from click import secho
+
 from .. import ErsiliaBase, throw_ersilia_exception
 from ..default import PREDEFINED_EXAMPLE_FILES
 from ..hub.content.card import ModelCard
@@ -440,6 +442,11 @@ class ExampleGenerator(ErsiliaBase):
             with open(file_name, "r") as f:
                 return f.read()
         else:
+            if try_predefined and not predefined_available:
+                secho(
+                    "No predefined examples found for the model. Generating random examples.",
+                    fg="yellow",
+                )
             self.logger.debug("Randomly sampling input")
             return self.random_example(
                 n_samples=n_samples, file_name=file_name, simple=simple

--- a/ersilia/utils/terminal.py
+++ b/ersilia/utils/terminal.py
@@ -176,7 +176,6 @@ def print_result_table(data):
             reader = csv.DictReader(file)
             data = [dict(row) for row in reader]
     elif isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
-        print("HERE")
         headers = list(data[0].keys())
         column_widths = {
             header: max(len(header), max(len(str(row[header])) for row in data)) + 5

--- a/ersilia/utils/terminal.py
+++ b/ersilia/utils/terminal.py
@@ -175,7 +175,8 @@ def print_result_table(data):
         with open(data, mode="r") as file:
             reader = csv.DictReader(file)
             data = [dict(row) for row in reader]
-    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+    elif isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+        print("HERE")
         headers = list(data[0].keys())
         column_widths = {
             header: max(len(header), max(len(str(row[header])) for row in data)) + 5


### PR DESCRIPTION
Closes #1486 

The PR makes the following updates:

1. The `--random` flag is set by default now in the example command, so the example command now indeed generates random samples unless `predefined` is requested, and an example file actually exists.
2. The `--as-table` flag for the `run` command has a shorter `-t` flag now.
3. `catalog` command accepts any extension and supports both tab separated files and comma separated files, however when the file extension is not `.tsv`, it serializes the file as a CSV by default.
4. The `example` command logs to the user if it is unable to find an example file for the model and that it is generating random samples. 