### PR TITLE
Bugfix/ python3.12 compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Python 3.12 Compatibility
 For systems running Python 3.12 , the setuptools library is required for fetching models. The ModelFetcher class automatically verifies the presence of setuptools and installs it if necessary. If the installation fails, ensure pip is properly configured or install setuptools manually:
 python -m pip install setuptools
 
+```bash
 python3.12 -m venv ersiliatest_env
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ersilia delete eos4e40
 
 Please see the [Ersilia Book](https://ersilia.gitbook.io/ersilia-book/) for more examples and detailed explanations.
 
-For Python versions 3.12 , Ersilia explicitly installs the setuptools library during installation. This is due to a compatibility issue in Python 3.12, which is described in python/cpython#95299.
+For Python versions 3.12, Ersilia explicitly installs the setuptools library during installation. This is due to a compatibility issue in Python 3.12, which is described in python/cpython#95299.
 
 Note: If you are using Python 3.12, you don’t need to take any manual action. The Ersilia CLI automatically handles this by installing setuptools as part of the setup process.
 

--- a/README.md
+++ b/README.md
@@ -97,14 +97,9 @@ ersilia delete eos4e40
 
 Please see the [Ersilia Book](https://ersilia.gitbook.io/ersilia-book/) for more examples and detailed explanations.
 
-## Troubleshooting
-Python 3.12 Compatibility
-For systems running Python 3.12 , the setuptools library is required for fetching models. The ModelFetcher class automatically verifies the presence of setuptools and installs it if necessary. If the installation fails, ensure pip is properly configured or install setuptools manually:
-python -m pip install setuptools
+For Python versions 3.12 , Ersilia explicitly installs the setuptools library during installation. This is due to a compatibility issue in Python 3.12, which is described in python/cpython#95299.
 
-```bash
-python3.12 -m venv ersiliatest_env
-```
+Note: If you are using Python 3.12, you don’t need to take any manual action. The Ersilia CLI automatically handles this by installing setuptools as part of the setup process.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ ersilia delete eos4e40
 
 Please see the [Ersilia Book](https://ersilia.gitbook.io/ersilia-book/) for more examples and detailed explanations.
 
+## Troubleshooting
+Python 3.12 Compatibility
+For systems running Python 3.12 , the setuptools library is required for fetching models. The ModelFetcher class automatically verifies the presence of setuptools and installs it if necessary. If the installation fails, ensure pip is properly configured or install setuptools manually:
+python -m pip install setuptools
+
+python3.12 -m venv ersiliatest_env
+
 ## Contribute
 
 The Ersilia Model Hub is a Free, Open Source Software and we highly value new contributors. There are several ways in which you can contribute to the project:

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -1,6 +1,8 @@
 import importlib
 import json
 import os
+import sys
+from ...utils.terminal import run_command
 from collections import namedtuple
 
 from ... import ErsiliaBase
@@ -22,6 +24,8 @@ from .lazy_fetchers.hosted import ModelHostedFetcher
 from .register.standard_example import ModelStandardExample
 
 FetchResult = namedtuple("FetchResult", ["fetch_success", "reason"])
+
+
 
 
 class ModelFetcher(ErsiliaBase):
@@ -93,6 +97,26 @@ class ModelFetcher(ErsiliaBase):
         ErsiliaBase.__init__(
             self, config_json=config_json, credentials_json=credentials_json
         )
+
+        # Python 3.12 Compatibility Check and Setuptools Handling
+        if sys.version_info >= (3, 12):
+            self.logger.info("Detected Python 3.12. Verifying setuptools...")
+            try:
+                importlib.import_module("setuptools")
+                self.logger.info("Setuptools is already installed.")
+            except ImportError:
+                self.logger.warning("Setuptools is not installed. Installing now...")
+                try:
+                    run_command("python -m pip install setuptools")
+                    self.logger.info("Setuptools installed successfully.")
+                except Exception as e:
+                    self.logger.error(
+                        f"Failed to install setuptools: {str(e)}"
+                    )
+                    raise RuntimeError(
+                        "Setuptools is required but could not be installed. Please resolve this manually."
+                    )
+
         self.ji = JsonModelsInterface(config_json=self.config_json)
         self.overwrite = overwrite
         self.mode = mode

--- a/ersilia/hub/fetch/fetch.py
+++ b/ersilia/hub/fetch/fetch.py
@@ -2,7 +2,6 @@ import importlib
 import json
 import os
 import sys
-from ...utils.terminal import run_command
 from collections import namedtuple
 
 from ... import ErsiliaBase
@@ -17,15 +16,13 @@ from ...utils.exceptions_utils.fetch_exceptions import (
     StandardModelExampleError,
 )
 from ...utils.exceptions_utils.throw_ersilia_exception import throw_ersilia_exception
-from ...utils.terminal import yes_no_input
+from ...utils.terminal import run_command, yes_no_input
 from . import STATUS_FILE
 from .lazy_fetchers.dockerhub import ModelDockerHubFetcher
 from .lazy_fetchers.hosted import ModelHostedFetcher
 from .register.standard_example import ModelStandardExample
 
 FetchResult = namedtuple("FetchResult", ["fetch_success", "reason"])
-
-
 
 
 class ModelFetcher(ErsiliaBase):
@@ -110,9 +107,7 @@ class ModelFetcher(ErsiliaBase):
                     run_command("python -m pip install setuptools")
                     self.logger.info("Setuptools installed successfully.")
                 except Exception as e:
-                    self.logger.error(
-                        f"Failed to install setuptools: {str(e)}"
-                    )
+                    self.logger.error(f"Failed to install setuptools: {str(e)}")
                     raise RuntimeError(
                         "Setuptools is required but could not be installed. Please resolve this manually."
                     )


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

**Description**
This PR aims to fix the `Python 3.12` compatibility issue with Bentoml. Implementation to be done within the fetch at the beginning (regardless of whether it's bentoml, or fastapi), just to be safe.
Bug: The issue stems from `pkg_resources` incompatibility with `Python 3.12` due to the removal of `pkgutil.ImpImporter`. 
`Python 3.12` removed `pkgutil.ImpImporter` and also stopped pre-installing `setuptools` in` venv` environments.` setuptools` is no longer automatically installed when you create a fresh environment with `Python 3.12`, specifically if you are using `venv` (the standard library's virtual environment tool). To access` setuptools`, you must explicitly install it after activating the environment
However, if you are using `Conda` to create the environment, `setuptools` might still be pre-installed. This is because  `Conda `handles package and environment dependencies differently and aims to provide a more complete setup by default.

**Changes to be made**

1. add a check for the python version in the code. 
2. if a user is operating from a 3.12 environment, try to import setuptools
3. if there's an import error, install setuptools (while also logging this on the CLI)
4. Add READme

**Status**

1. Python Version Check:

  - Added a check for `Python version >= 3.12` using `sys.version_info`.

2. Setuptools Import and Installation:

- Tries to import `setuptools` using `importlib.import_module`.
- If `ImportError` occurs, installs `setuptools` using `run_command("pip install setuptools")` and logs the process.

3. Logging:

- Detailed logging for successful installation, detection of `setuptools`, and error handling.

4. Documented the fix for README

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Fix #1379 