### PR TITLE
py3.12 incompatibility with scipy and rdkit update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ fuzzywuzzy = { version = "^0.18.0", optional = true }
 sphinx = { version = ">=6.0.0", optional = true }           # for minimum version and support for Python 3.10
 jinja2 = { version = "^3.1.2", optional = true }
 scipy = { version = "<=1.10.0", optional = true }
-rdkit-pypi = { version = "*", optional = true }
 nox = { version = "*", optional = true }
 rich = { version = "*", optional = true }
 ruff = { version = "*", optional = true }
@@ -70,7 +69,7 @@ pre-commit = { version = "*", optional = true }
 # Instead of using poetry dependency groups, we use extras to make it pip installable
 lake = ["isaura"]
 docs = ["sphinx", "jinja2"]
-test = ["pytest", "pytest-asyncio", "pytest-benchmark", "nox", "rich", "fuzzywuzzy", "scipy", "rdkit-pypi", "ruff", "pre-commit"]
+test = ["pytest", "pytest-asyncio", "pytest-benchmark", "nox", "rich", "fuzzywuzzy", "scipy", "ruff", "pre-commit"]
 #all = [lake, docs, test]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pytest-benchmark = { version = "<=4.0.0", optional = true }
 fuzzywuzzy = { version = "^0.18.0", optional = true }
 sphinx = { version = ">=6.0.0", optional = true }           # for minimum version and support for Python 3.10
 jinja2 = { version = "^3.1.2", optional = true }
-scipy = { version = "<=1.10.0", optional = true }
+scipy = { version = "*", optional = true }
 nox = { version = "*", optional = true }
 rich = { version = "*", optional = true }
 ruff = { version = "*", optional = true }

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -9,6 +9,10 @@ from ersilia.cli.commands.run import run_cmd
 from ersilia.core.model import ErsiliaModel
 from ersilia.core.session import Session
 from ersilia.serve.standard_api import StandardCSVRunApi
+from ersilia.setup.requirements.compound import (
+    ChemblWebResourceClientRequirement,
+    RdkitRequirement,
+)
 from ersilia.utils.logging import logger
 
 from .utils import create_compound_input_csv
@@ -24,6 +28,10 @@ MIN_WEIGHT = 40.0
 MAX_WEIGHT = 60.0
 HEADER = ["key", "input", "value"]
 
+@pytest.fixture
+def setup():
+    RdkitRequirement()
+    ChemblWebResourceClientRequirement()
 
 @pytest.fixture
 def mock_fetcher():
@@ -119,7 +127,7 @@ def mock_std_api_post():
 
 
 @pytest.fixture
-def mock_session(compound_csv):
+def mock_session(setup, compound_csv):
     with (
         patch.object(Session, "current_model_id", return_value=MODEL_ID),
         patch.object(Session, "current_service_class", return_value="pulled_docker"),


### PR DESCRIPTION
**Description**
- [x] rdkit removed from the test extra in the `pyproject.toml` and added as fixture in the `test_run.py`, to be installed by Ersilia  when necessary.
- [x] scipy version version specified in  `pyproject.toml` `version = "<=1.10.0"` is not supported by  `py3.12` and updated to be version = "*` to be compatible withit.

Fixes #1494