### PR TITLE
Feature/fix long output prints

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -9,16 +9,19 @@ from ...utils.terminal import print_result_table
 from .. import echo
 from . import ersilia_cli
 
-def truncate_output(output, max_items=10):
+
+def truncate_output(output, max_items=10, max_chars=500):
     """
-    Truncates long outputs for clarity.
+    Truncates long outputs for better readability.
 
     Parameters
     ----------
     output : Any
-        The output to process and truncate if necessary.
+        The output to process and truncate.
     max_items : int, optional
-        The maximum number of items to display for arrays/lists.
+        Maximum number of items to display for arrays/lists or dictionary keys.
+    max_chars : int, optional
+        Maximum number of characters to display for strings.
 
     Returns
     -------
@@ -26,74 +29,108 @@ def truncate_output(output, max_items=10):
         The truncated output as a formatted string.
     """
     if isinstance(output, list):
-        # Truncate lists to the first `max_items` items
         if len(output) > max_items:
             return f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
         return str(output)
     elif isinstance(output, dict):
-        # Convert dict to JSON and truncate if necessary
         formatted = json.dumps(output, indent=4)
         lines = formatted.splitlines()
         if len(lines) > max_items:
             return "\n".join(lines[:max_items]) + f"\n... (and {len(lines) - max_items} more lines)"
         return formatted
     elif isinstance(output, str):
-        # Truncate strings with a character limit
-        if len(output) > 500:
-            return f"{output[:500]}... (truncated)"
+        if len(output) > max_chars:
+            return f"{output[:max_chars]}... (truncated)"
         return output
     else:
         return str(output)
 
 
-def run(input, output, batch_size, as_table):
-    session = Session(config_json=None)
-    model_id = session.current_model_id()
-    service_class = session.current_service_class()
-    track_runs = session.tracking_status()
+def run_cmd():
+    """
+    Runs a specified model.
 
-    output_source = session.current_output_source()
-    if model_id is None:
-        echo(
-            "No model seems to be served. Please run 'ersilia serve ...' before.",
-            fg="red",
+    This command allows users to run a specified model with given inputs.
+
+    Returns
+    -------
+    function
+        The run command function to be used by the CLI and for testing in the pytest.
+
+    Examples
+    --------
+    .. code-block:: console
+
+        Run a model by its ID with input data:
+        $ ersilia run -i <input_data> --as-table
+
+        Run a model with batch size:
+        $ ersilia run -i <input_data> -b 50
+    """
+
+    # Example usage: ersilia run -i {INPUT} [-o {OUTPUT} -b {BATCH_SIZE}]
+    @ersilia_cli.command(short_help="Run a served model", help="Run a served model")
+    @click.option("-i", "--input", "input", required=True, type=click.STRING)
+    @click.option(
+        "-o", "--output", "output", required=False, default=None, type=click.STRING
+    )
+    @click.option(
+        "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
+    )
+    @click.option("--as-table/-t", is_flag=True, default=False)
+    def run(input, output, batch_size, as_table):
+        session = Session(config_json=None)
+        model_id = session.current_model_id()
+        service_class = session.current_service_class()
+        track_runs = session.tracking_status()
+
+        output_source = session.current_output_source()
+        if model_id is None:
+            echo(
+                "No model seems to be served. Please run 'ersilia serve ...' before.",
+                fg="red",
+            )
+            return
+
+        mdl = ErsiliaModel(
+            model_id,
+            output_source=output_source,
+            service_class=service_class,
+            config_json=None,
+            track_runs=track_runs,
         )
-        return
+        result = mdl.run(
+            input=input,
+            output=output,
+            batch_size=batch_size,
+            track_run=track_runs,
+        )
 
-    mdl = ErsiliaModel(
-        model_id,
-        output_source=output_source,
-        service_class=service_class,
-        config_json=None,
-        track_runs=track_runs,
-    )
-    result = mdl.run(
-        input=input,
-        output=output,
-        batch_size=batch_size,
-        track_run=track_runs,
-    )
-
-    # Process the result
-    if isinstance(result, types.GeneratorType):
-        for result in mdl.run(input=input, output=output, batch_size=batch_size):
-            if result is not None:
-                formatted = truncate_output(result)
-                if as_table:
-                    print_result_table(formatted)
+        if isinstance(result, types.GeneratorType):
+            for result in mdl.run(input=input, output=output, batch_size=batch_size):
+                if result is not None:
+                    truncated = truncate_output(result)  # Truncate the output
+                    if as_table:
+                        print_result_table(truncated)  # Print truncated result as table
+                    else:
+                        echo(truncated)  # Print truncated raw output
                 else:
-                    echo(formatted)
-            else:
-                echo("Something went wrong", fg="red")
-    else:
-        # Truncate long outputs
-        formatted = truncate_output(result)
-        if as_table:
-            print_result_table(formatted)
+                    echo("Something went wrong", fg="red")  # Print error if result is None
         else:
-            try:
-                echo(formatted)
-            except:
-                print_result_table(formatted)
+            # Allow user to print full result as a table
+            if as_table:
+                if isinstance(result, dict):
+                    # Print full result as table if available
+                    print_result_table(result)  
+                else:
+                    echo("Result cannot be displayed as a table", fg="red")
+            else:
+                try:
+                    truncated = truncate_output(result)  # Truncate only for terminal output
+                    echo(truncated)  # Print truncated result
+                except Exception as e:
+                    echo(f"Error: {e}", fg="red")  # Print error if echo fails
+                    print_result_table(result)  # Fallback: Print full result as a table
+
 
     return run

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -30,13 +30,18 @@ def truncate_output(output, max_items=10, max_chars=500):
     """
     if isinstance(output, list):
         if len(output) > max_items:
-            return f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
+            return (
+                f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
+            )
         return str(output)
     elif isinstance(output, dict):
         formatted = json.dumps(output, indent=4)
         lines = formatted.splitlines()
         if len(lines) > max_items:
-            return "\n".join(lines[:max_items]) + f"\n... (and {len(lines) - max_items} more lines)"
+            return (
+                "\n".join(lines[:max_items])
+                + f"\n... (and {len(lines) - max_items} more lines)"
+            )
         return formatted
     elif isinstance(output, str):
         if len(output) > max_chars:
@@ -109,28 +114,25 @@ def run_cmd():
         if isinstance(result, types.GeneratorType):
             for result in mdl.run(input=input, output=output, batch_size=batch_size):
                 if result is not None:
-                    truncated = truncate_output(result)  # Truncate the output
+                    truncated = truncate_output(result)
                     if as_table:
-                        print_result_table(truncated)  # Print truncated result as table
+                        print_result_table(truncated)
                     else:
-                        echo(truncated)  # Print truncated raw output
+                        echo(truncated)
                 else:
-                    echo("Something went wrong", fg="red")  # Print error if result is None
+                    echo("Something went wrong", fg="red")
         else:
-            # Allow user to print full result as a table
             if as_table:
                 if isinstance(result, dict):
-                    # Print full result as table if available
-                    print_result_table(result)  
+                    print_result_table(result)
                 else:
                     echo("Result cannot be displayed as a table", fg="red")
             else:
                 try:
-                    truncated = truncate_output(result)  # Truncate only for terminal output
-                    echo(truncated)  # Print truncated result
+                    truncated = truncate_output(result)
+                    echo(truncated)
                 except Exception as e:
-                    echo(f"Error: {e}", fg="red")  # Print error if echo fails
-                    print_result_table(result)  # Fallback: Print full result as a table
-
+                    echo(f"Error: {e}", fg="red")
+                    print_result_table(result)
 
     return run

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -1,54 +1,12 @@
-import json
 import types
 
 import click
 
 from ... import ErsiliaModel
 from ...core.session import Session
-from ...utils.terminal import print_result_table
+from ...utils.terminal import print_result_table, truncate_output
 from .. import echo
 from . import ersilia_cli
-
-
-def truncate_output(output, max_items=10, max_chars=500):
-    """
-    Truncates long outputs for better readability.
-
-    Parameters
-    ----------
-    output : Any
-        The output to process and truncate.
-    max_items : int, optional
-        Maximum number of items to display for arrays/lists or dictionary keys.
-    max_chars : int, optional
-        Maximum number of characters to display for strings.
-
-    Returns
-    -------
-    str
-        The truncated output as a formatted string.
-    """
-    if isinstance(output, list):
-        if len(output) > max_items:
-            return (
-                f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
-            )
-        return str(output)
-    elif isinstance(output, dict):
-        formatted = json.dumps(output, indent=4)
-        lines = formatted.splitlines()
-        if len(lines) > max_items:
-            return (
-                "\n".join(lines[:max_items])
-                + f"\n... (and {len(lines) - max_items} more lines)"
-            )
-        return formatted
-    elif isinstance(output, str):
-        if len(output) > max_chars:
-            return f"{output[:max_chars]}... (truncated)"
-        return output
-    else:
-        return str(output)
 
 
 def run_cmd():

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -9,102 +9,91 @@ from ...utils.terminal import print_result_table
 from .. import echo
 from . import ersilia_cli
 
-
-def summarize_output(output, max_items=20):
+def truncate_output(output, max_items=10):
     """
-    Summarize the output to display only the first few elements.
-    If the output is a list or dictionary, truncate it for better readability.
+    Truncates long outputs for clarity.
 
     Parameters
     ----------
-    output : dict, list, or any object
-        The output to summarize.
+    output : Any
+        The output to process and truncate if necessary.
     max_items : int, optional
-        The maximum number of items to display, by default 10.
+        The maximum number of items to display for arrays/lists.
 
     Returns
     -------
     str
-        The summarized output as a string.
+        The truncated output as a formatted string.
     """
     if isinstance(output, list):
+        # Truncate lists to the first `max_items` items
         if len(output) > max_items:
-            return json.dumps(output[:max_items] + ["..."], indent=4)
+            return f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
+        return str(output)
     elif isinstance(output, dict):
-        if len(output) > max_items:
-            truncated = dict(list(output.items())[:max_items])
-            truncated["..."] = f"+{len(output) - max_items} more items"
-            return json.dumps(truncated, indent=4)
-    return json.dumps(output, indent=4)
+        # Convert dict to JSON and truncate if necessary
+        formatted = json.dumps(output, indent=4)
+        lines = formatted.splitlines()
+        if len(lines) > max_items:
+            return "\n".join(lines[:max_items]) + f"\n... (and {len(lines) - max_items} more lines)"
+        return formatted
+    elif isinstance(output, str):
+        # Truncate strings with a character limit
+        if len(output) > 500:
+            return f"{output[:500]}... (truncated)"
+        return output
+    else:
+        return str(output)
 
 
-def run_cmd():
-    """
-    Runs a specified model.
-    """
+def run(input, output, batch_size, as_table):
+    session = Session(config_json=None)
+    model_id = session.current_model_id()
+    service_class = session.current_service_class()
+    track_runs = session.tracking_status()
 
-    @ersilia_cli.command(short_help="Run a served model", help="Run a served model")
-    @click.option("-i", "--input", "input", required=True, type=click.STRING)
-    @click.option(
-        "-o", "--output", "output", required=False, default=None, type=click.STRING
-    )
-    @click.option(
-        "-b", "--batch_size", "batch_size", required=False, default=100, type=click.INT
-    )
-    @click.option("--as-table/-t", is_flag=True, default=False)
-    @click.option("--verbose", is_flag=True, help="Show the full output.")
-    def run(input, output, batch_size, as_table, verbose):
-        session = Session(config_json=None)
-        model_id = session.current_model_id()
-        service_class = session.current_service_class()
-        track_runs = session.tracking_status()
-
-        output_source = session.current_output_source()
-        if model_id is None:
-            echo(
-                "No model seems to be served. Please run 'ersilia serve ...' before.",
-                fg="red",
-            )
-            return
-
-        mdl = ErsiliaModel(
-            model_id,
-            output_source=output_source,
-            service_class=service_class,
-            config_json=None,
-            track_runs=track_runs,
+    output_source = session.current_output_source()
+    if model_id is None:
+        echo(
+            "No model seems to be served. Please run 'ersilia serve ...' before.",
+            fg="red",
         )
-        result = mdl.run(
-            input=input,
-            output=output,
-            batch_size=batch_size,
-            track_run=track_runs,
-        )
+        return
 
-        def process_result(result):
-            if verbose:
-                return json.dumps(result, indent=4)
-            else:
-                return summarize_output(result)
+    mdl = ErsiliaModel(
+        model_id,
+        output_source=output_source,
+        service_class=service_class,
+        config_json=None,
+        track_runs=track_runs,
+    )
+    result = mdl.run(
+        input=input,
+        output=output,
+        batch_size=batch_size,
+        track_run=track_runs,
+    )
 
-        if isinstance(result, types.GeneratorType):
-            for result in mdl.run(input=input, output=output, batch_size=batch_size):
-                if result is not None:
-                    formatted = process_result(result)
-                    if as_table:
-                        print_result_table(formatted)
-                    else:
-                        echo(formatted)
+    # Process the result
+    if isinstance(result, types.GeneratorType):
+        for result in mdl.run(input=input, output=output, batch_size=batch_size):
+            if result is not None:
+                formatted = truncate_output(result)
+                if as_table:
+                    print_result_table(formatted)
                 else:
-                    echo("Something went wrong", fg="red")
-        else:
-            formatted = process_result(result)
-            if as_table:
-                print_result_table(formatted)
-            else:
-                try:
                     echo(formatted)
-                except Exception:
-                    print_result_table(result)
+            else:
+                echo("Something went wrong", fg="red")
+    else:
+        # Truncate long outputs
+        formatted = truncate_output(result)
+        if as_table:
+            print_result_table(formatted)
+        else:
+            try:
+                echo(formatted)
+            except:
+                print_result_table(formatted)
 
     return run

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -1,3 +1,4 @@
+import json
 import types
 
 import click
@@ -70,27 +71,24 @@ def run_cmd():
         )
 
         if isinstance(result, types.GeneratorType):
-            for result in mdl.run(input=input, output=output, batch_size=batch_size):
-                if result is not None:
-                    truncated = truncate_output(result)
+            for result_item in result:
+                if result_item is not None:
+                    truncated_result = truncate_output(result_item, max_length=10)
+                    formatted = json.dumps(truncated_result, indent=4)
                     if as_table:
-                        print_result_table(truncated)
+                        print_result_table(formatted)
                     else:
-                        echo(truncated)
+                        echo(formatted)
                 else:
                     echo("Something went wrong", fg="red")
         else:
+            truncated_result = truncate_output(result, max_length=10)
             if as_table:
-                if isinstance(result, dict):
-                    print_result_table(result)
-                else:
-                    echo("Result cannot be displayed as a table", fg="red")
+                print_result_table(truncated_result)
             else:
                 try:
-                    truncated = truncate_output(result)
-                    echo(truncated)
-                except Exception as e:
-                    echo(f"Error: {e}", fg="red")
-                    print_result_table(result)
+                    echo(json.dumps(truncated_result, indent=4))
+                except:
+                    print_result_table(truncated_result)
 
     return run

--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -69,14 +69,22 @@ def run_cmd():
             batch_size=batch_size,
             track_run=track_runs,
         )
+
+        # Process and display the results
+        def display_result(res):
+            if isinstance(res, list) and len(res) > 10:
+                # Truncate long lists for clarity
+                echo(json.dumps(res[:10], indent=4) + "\n... (truncated)", fg="yellow")
+            else:
+                echo(json.dumps(res, indent=4))
+
         if isinstance(result, types.GeneratorType):
-            for result in mdl.run(input=input, output=output, batch_size=batch_size):
-                if result is not None:
-                    formatted = json.dumps(result, indent=4)
+            for res in result:
+                if res is not None:
                     if as_table:
-                        print_result_table(formatted)
+                        print_result_table(res)
                     else:
-                        echo(formatted)
+                        display_result(res)
                 else:
                     echo("Something went wrong", fg="red")
         else:
@@ -84,8 +92,8 @@ def run_cmd():
                 print_result_table(result)
             else:
                 try:
-                    echo(result)
-                except:
-                    print_result_table(result)
+                    display_result(result)
+                except Exception as e:
+                    echo(f"An error occurred while displaying the result: {str(e)}", fg="red")
 
     return run

--- a/ersilia/utils/terminal.py
+++ b/ersilia/utils/terminal.py
@@ -159,6 +159,51 @@ def yes_no_input(prompt, default_answer, timeout=5):
         return True
 
 
+def truncate_output(output, max_items=10, max_chars=500):
+    """
+    Truncates long outputs for better readability.
+
+    Parameters
+    ----------
+    output : Any
+        The output to process and truncate.
+    max_items : int, optional
+        Maximum number of items to display for arrays/lists or dictionary keys.
+    max_chars : int, optional
+        Maximum number of characters to display for strings.
+
+    Returns
+    -------
+    str
+        The truncated output as a formatted string.
+    """
+    if isinstance(output, list):
+        if len(output) > max_items:
+            return (
+                f"{output[:max_items]} ... (and {len(output) - max_items} more items)"
+            )
+        return str(output)
+    if isinstance(output, dict):
+        if len(output) > max_items:
+            keys = list(output.keys())[:max_items]
+            truncated = {key: output[key] for key in keys}
+            remaining_lines = len(output) - max_items
+            return f"{json.dumps(truncated, indent=4)}\n... (and {remaining_lines} more lines)"
+        return output
+
+    elif isinstance(output, str):
+        if len(output) > max_chars:
+            suffix = " ... (truncated)"
+            truncated = output[
+                : max_chars - len(suffix) - 1
+            ].rstrip()  # Adjust for space
+            return f"{truncated} {suffix}"
+        return output
+
+    else:
+        return str(output)
+
+
 def print_result_table(data):
     """
     Print a result table from CSV or JSON-like data.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,6 @@
-import pytest
+import json
 from ersilia.utils.terminal import truncate_output
+
 
 def test_truncate_output_list():
     # Test truncation for a long list
@@ -7,13 +8,13 @@ def test_truncate_output_list():
     truncated = truncate_output(output, max_items=10)
     assert truncated == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9] ... (and 10 more items)"
 
+
 def test_truncate_output_dict():
     # Test truncation for a long dictionary
     output = {f"key{i}": i for i in range(20)}  # Dictionary with 20 key-value pairs
     truncated = truncate_output(output, max_items=5)
-    assert truncated.startswith("{\n    \"key0\": 0,")
+    assert truncated.startswith('{\n    "key0": 0,')
     assert truncated.endswith("... (and 15 more lines)")
-
 
 
 def test_truncate_output_short_list():
@@ -22,6 +23,7 @@ def test_truncate_output_short_list():
     truncated = truncate_output(output, max_items=10)
     assert truncated == "[1, 2, 3]"
 
+
 def test_truncate_output_short_dict():
     # Test for a short dictionary that doesn't need truncation
     output = {"key1": 1, "key2": 2}
@@ -29,11 +31,13 @@ def test_truncate_output_short_dict():
     assert "key1" in truncated
     assert "key2" in truncated
 
+
 def test_truncate_output_short_string():
     # Test for a short string that doesn't need truncation
     output = "Short string"
     truncated = truncate_output(output, max_chars=50)
     assert truncated == "Short string"
+
 
 def test_truncate_output_other_types():
     # Test for non-list, non-dict, non-string types

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,42 @@
+import pytest
+from ersilia.utils.terminal import truncate_output
+
+def test_truncate_output_list():
+    # Test truncation for a long list
+    output = list(range(20))  # List with 20 items
+    truncated = truncate_output(output, max_items=10)
+    assert truncated == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9] ... (and 10 more items)"
+
+def test_truncate_output_dict():
+    # Test truncation for a long dictionary
+    output = {f"key{i}": i for i in range(20)}  # Dictionary with 20 key-value pairs
+    truncated = truncate_output(output, max_items=5)
+    assert truncated.startswith("{\n    \"key0\": 0,")
+    assert truncated.endswith("... (and 15 more lines)")
+
+
+
+def test_truncate_output_short_list():
+    # Test for a short list that doesn't need truncation
+    output = [1, 2, 3]
+    truncated = truncate_output(output, max_items=10)
+    assert truncated == "[1, 2, 3]"
+
+def test_truncate_output_short_dict():
+    # Test for a short dictionary that doesn't need truncation
+    output = {"key1": 1, "key2": 2}
+    truncated = truncate_output(output, max_items=10)
+    assert "key1" in truncated
+    assert "key2" in truncated
+
+def test_truncate_output_short_string():
+    # Test for a short string that doesn't need truncation
+    output = "Short string"
+    truncated = truncate_output(output, max_chars=50)
+    assert truncated == "Short string"
+
+def test_truncate_output_other_types():
+    # Test for non-list, non-dict, non-string types
+    output = 12345
+    truncated = truncate_output(output)
+    assert truncated == "12345"


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

This PR addresses an issue where large outputs clutter the terminal, making it difficult to interpret results effectively. Specifically, some models, such as descriptors, produce outputs with thousands of columns which floods the terminal and reduce readability.

**Changes to be made**
Added `truncate_output `Function:
Handles truncation for large outputs, summarizing them with ellipses (...) and providing context about omitted parts.
Ensures clarity and concise representation of outputs.
Modified Output Handling:
Applied `truncate_output `to both regular and generator outputs.
Ensured the truncated version is passed to` echo` or `print_result_table` as applicable.

**Steps taken to implement the fix**
Created a utility function, `truncate_output`, within the output handling module.
Updated the generator loop and regular output sections to conditionally truncate results based on size.
Verified that truncated outputs integrate seamlessly with echo and `print_result_table` functions.
**Status**

- Implementation complete.
- Tested some models:  `eos4wt0`, `eos4u6p`, `eos7w6n`, `eos4avb`, `eos3b5e`, and  `eos69p9`.
- All tests pass successfully when run locally.

**To do**

Review and address feedback

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

fixes #1455