### PR TITLE
Task: Add a warning message when Ersilia found running in a Python env less than 3.8 #1501

### DIFF
--- a/ersilia/cli/create_cli.py
+++ b/ersilia/cli/create_cli.py
@@ -1,6 +1,9 @@
+import sys
+
 from ..auth.auth import Auth
 from .cmd import Command
 from .commands import ersilia_cli
+from .messages import VersionNotSupported
 
 
 def create_ersilia_cli():
@@ -9,12 +12,25 @@ def create_ersilia_cli():
 
     This function initializes the Command class, checks if the user is a contributor,
     and dynamically imports and executes various CLI commands based on the user's role.
+    It also verifies that Python 3.8+ is being used.
 
     Returns
     -------
-    ersilia_cli : module
-        The configured Ersilia CLI module.
+    ersilia_cli : module | None
+        The configured Ersilia CLI module if Python version >= 3.8
+        None if the program exits due to version check failure
+    Raises
+    ------
+    SystemExit
+        If Python version is less than 3.8
+    Notes
+    -----
+    This function will terminate the program with sys.exit(1) if Python version < 3.8
     """
+    # Check Python version
+    if sys.version_info.major < 3 or sys.version_info.minor < 8:
+        VersionNotSupported(sys.version.major, sys.version.minor)
+
     is_contributor = Auth().is_contributor()
 
     cmd = Command()

--- a/ersilia/cli/create_cli.py
+++ b/ersilia/cli/create_cli.py
@@ -29,7 +29,7 @@ def create_ersilia_cli():
     """
     # Check Python version
     if sys.version_info.major < 3 or sys.version_info.minor < 8:
-        VersionNotSupported(sys.version.major, sys.version.minor)
+        VersionNotSupported(sys.version.major, sys.version.minor).echo()
 
     is_contributor = Auth().is_contributor()
 

--- a/ersilia/cli/messages.py
+++ b/ersilia/cli/messages.py
@@ -72,3 +72,39 @@ class ModelNotInLocal(object):
             )
         )
         sys.exit(0)
+
+
+class VersionNotSupported:
+    """
+    A class to handle the scenario when the python version used is less than 3.8
+
+    Attributes
+    ----------
+    versionMajor : int
+        The user's major version (e.g 3 in version 3.8).
+    versionMinor : int
+        The user's minor version (e.g 8 in version 3.8).
+
+    Methods
+    -------
+    echo()
+        prints an error message to the console in red and exits the program.
+    """
+
+    def __init__(self, versionMajor, versionMinor):
+        self.versionMajor = versionMajor
+        self.versionMinor = versionMinor
+
+    def echo(self):
+        """
+        Prints an error indicating the python version is not supported and exits the program.
+        """
+        echo(
+            "Error: This application requires Python 3.8 or higher.",
+            fg="red",
+        )
+        echo(
+            "Current version: {sys.version_info.major}.{sys.version_info.minor}",
+            fg="red",
+        )
+        sys.exit(1)


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**
Added a check to the create create_cli module to check if the user's version is less than 3.8 and returns an error message in red.

**Status**
- Added the check to the create_cli.py
- updated the messages.py for the VersionNotSupported class which returns the error message and exits the program

Related to #1501