### PR TITLE
fix resolve pack method

### DIFF
--- a/ersilia/utils/docker.py
+++ b/ersilia/utils/docker.py
@@ -31,9 +31,11 @@ def resolve_pack_method_docker(model_id):
     model_image = client.images.get(f"{DOCKERHUB_ORG}/{model_id}:{docker_tag}")
     image_history = model_image.history()
     for hist in image_history:
-        # Very hacky, but works bec we don't have nginx in ersilia-pack images
-        if "nginx" in hist["CreatedBy"]:
-            return PACK_METHOD_BENTOML
+        tags = hist.get("Tags")
+        if tags and any(tag.endswith(":latest") for tag in tags):
+            # Very hacky, but works bec we don't have nginx in ersilia-pack images
+            if "nginx" in hist["CreatedBy"]:
+                return PACK_METHOD_BENTOML
     return PACK_METHOD_FASTAPI
 
 


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

The resolve pack method for Docker images was not working as the history had several versions some of which contained nginx, which is what was defined to decide between bentoml or fastapi

**Changes to be made**

I have added an if statement to check only in the latest version

**Status**

Completed. I have tried to use it with FastAPI packed models that were originally packed with BentoML (eos3b5e) and 
models that have been packed with BentoML (eos9f6t) for example. Works in both situations.

**To do**

None

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #1509