### PR TITLE
Resolve duplication of values in CSV serialization

### DIFF
--- a/ersilia/serve/standard_api.py
+++ b/ersilia/serve/standard_api.py
@@ -498,12 +498,17 @@ class StandardCSVRunApi(ErsiliaBase):
             writer = csv.writer(f)
             writer.writerow(self.header)
             for i_d, r_d in zip(input_data, result):
+                # Prepare the row to be written
                 r = [i_d["key"], i_d["input"]]
-                for k in self.header[2:]:
+                # Iterate over the header and extract values from the row-wise result
+                for i, k in enumerate(self.header[2:]):
                     if isinstance(r_d, dict):
                         v = r_d[k]
+                    elif isinstance(r_d, list):
+                        v = r_d[i]
                     else:
                         v = r_d
+
                     if isinstance(v, list):
                         r += v
                     else:


### PR DESCRIPTION
Fix csv serialization if input result is neither a dict nor a single value

Closes #1541 