### PR TITLE
Added warning for unsupported Python versions (<3.8)

### DIFF
--- a/ersilia/cli/create_cli.py
+++ b/ersilia/cli/create_cli.py
@@ -1,7 +1,7 @@
+import sys
 from ..auth.auth import Auth
 from .cmd import Command
 from .commands import ersilia_cli
-
 
 def create_ersilia_cli():
     """
@@ -15,10 +15,13 @@ def create_ersilia_cli():
     ersilia_cli : module
         The configured Ersilia CLI module.
     """
+    # Check Python version
+    if sys.version_info < (3.8,):
+        print("\033[91mWARNING: Ersilia does not support Python versions below 3.8. Please upgrade your Python version.\033[0m")
+
     is_contributor = Auth().is_contributor()
 
     cmd = Command()
-
     cmd.auth()
     cmd.catalog()
     cmd.uninstall()
@@ -37,7 +40,6 @@ def create_ersilia_cli():
     cmd.run()
 
     # TODO: functions only for contributors
-    # Functions only for contributors
     if is_contributor:
         cmd.setup()
 


### PR DESCRIPTION
**Description**  

Added a Python version check to `create_cli.py` to ensure users are running Python 3.8 or higher. If the version is lower, a warning message is displayed in red.  

**Changes to be made**  

Modify `create_cli.py` to check `sys.version_info` and display a warning if the version is below 3.8. The warning message is formatted in red for better visibility.  

**Status**  

The Python version check has been implemented and tested. The warning message appears correctly for Python versions below 3.8.  

**To do**  

- Review the changes for any potential improvements.  
- Merge the PR once approved.  

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Related to #1501 