### PR TITLE
Update README file format

### DIFF
--- a/.github/scripts/airtableops.py
+++ b/.github/scripts/airtableops.py
@@ -126,7 +126,11 @@ class ReadmeMetadata:
         print(bi.as_dict())
         return bi
 
-    def write_information(self, data: BaseInformation, readme_path=None):
+    def write_information_0(self, data: BaseInformation, readme_path=None):
+        """
+        Generates the README file using the old format.
+        
+        """
         d = data.as_dict()
         text = "# {0}\n\n".format(d["Title"])
         text += "{0}\n\n".format(d["Description"].rstrip("\n"))
@@ -173,6 +177,129 @@ class ReadmeMetadata:
         else:
             with open(readme_path, "w") as f:
                 f.write(text)
+
+    def write_information_1(self, data: BaseInformation, readme_path=None):
+        """
+        Generates the README file using the new format.
+        """
+        d = data.as_dict()
+        text = "# {0}\n\n".format(d.get("Title", "Model Title"))
+        # Description and incorporation date
+        text += "**Description**  \n"
+        text += "{0}\n\n".format(d.get("Description", "No description provided").rstrip("\n"))
+        if "Model Incorporation Date" in d:
+            text += "**Model Incorporation Date:** {0}\n\n".format(d["Model Incorporation Date"])
+        text += "---\n\n"
+
+        # Identifiers
+        text += "## Identifiers\n"
+        text += "- **Ersilia Identifier:** {0}\n".format(d.get("Identifier", ""))
+        text += "- **Slug:** {0}\n\n".format(d.get("Slug", ""))
+
+        # Domain
+        text += "## Domain\n"
+        text += "- **Task:** {0}\n".format(d.get("Task", ""))
+        text += "- **Subtask:** {0}\n".format(d.get("Subtask", ""))
+        text += "- **Biomedical Area:** {0}\n".format(d.get("Biomedical Area", ""))
+        text += "- **Target Organism:** {0}\n".format(d.get("Target Organism", ""))
+        text += "- **Tags:** {0}\n\n".format(d.get("Tags", ""))
+
+        # Input
+        text += "## Input\n"
+        text += "- **Input Type:** {0}\n".format(d.get("Input", ""))
+        text += "- **Input Shape:** {0}\n\n".format(d.get("Input Shape", ""))
+
+        # Output
+        text += "## Output\n"
+        text += "- **Output Type:** {0}\n".format(d.get("Output", ""))
+        text += "- **Output Dimension:** {0}\n".format(d.get("Output Dimension", ""))
+        text += "- **Output Consistency:** {0}\n".format(d.get("Output Consistency", ""))
+        text += "- **Interpretation:** {0}\n\n".format(d.get("Interpretation", ""))
+
+        # Output Columns (if provided)
+        if "Output Columns" in d:
+            text += "**Output Columns (up to 10):**\n\n"
+            text += "| Name | Type | Direction | Description |\n"
+            text += "|------|------|-----------|-------------|\n"
+            for col in d["Output Columns"]:
+                text += "| {0} | {1} | {2} | {3} |\n".format(
+                    col.get("Name", ""),
+                    col.get("Type", ""),
+                    col.get("Direction", ""),
+                    col.get("Description", "")
+                )
+            text += "\n"
+
+        # Source and Deployment
+        text += "## Source and Deployment\n"
+        text += "- **Source:** {0}\n".format(d.get("Source", ""))
+        text += "- **Source Type:** {0}\n".format(d.get("Source Type", ""))
+        if "DockerHub" in d:
+            text += "- **DockerHub:** {0}\n".format(d["DockerHub"])
+        text += "\n"
+
+        # Resource Consumption
+        text += "## Resource Consumption\n"
+        text += "- **Model Size:** {0}\n".format(d.get("Model Size", ""))
+        text += "- **Environment Size:** {0}\n".format(d.get("Environment Size", ""))
+        text += "- **Image Size:** {0}\n".format(d.get("Image Size", ""))
+        text += "\n"
+        text += "**Computational Performance:**\n"
+        text += "- **1 input:** {0}\n".format(d.get("Computational Performance 1", ""))
+        text += "- **10 inputs:** {0}\n".format(d.get("Computational Performance 10", ""))
+        text += "- **100 inputs:** {0}\n".format(d.get("Computational Performance 100", ""))
+        text += "\n"
+
+        # References
+        text += "## References\n"
+        text += "- **Source Code:** {0}\n".format(d.get("Source Code", ""))
+        text += "- **Publication:** {0}\n".format(d.get("Publication", ""))
+        if "Publication Type" in d:
+            text += "  - **Publication Type:** {0}\n".format(d["Publication Type"])
+        if "Publication Year" in d:
+            text += "  - **Publication Year:** {0}\n".format(d["Publication Year"])
+        text += "\n"
+
+        # License
+        text += "## License\n"
+        text += "- **Package License:** {0}\n".format(d.get("Package License", ""))
+        text += "- **Model License:** {0}\n".format(d.get("Model License", ""))
+        text += "\n"
+        text += "**Notice:**  \n"
+        text += "Ersilia grants access to these models \"as is\" provided by the original authors. Please refer to the original code repository and/or publication if you use the model in your research.\n\n"
+
+        # About Ersilia
+        text += "## About Ersilia\n"
+        text += "The Ersilia Open Source Initiative is a non-profit organization fueling sustainable research in the Global South.\n"
+        if readme_path is None:
+            return text
+        else:
+            with open(readme_path, "w") as f:
+                f.write(text)
+
+    def write_information(self, data: BaseInformation, readme_path=None, version=None):
+        """
+        Dynamically selects the appropriate README format based on the provided version flag
+        or by inspecting the metadata.
+        
+        :param data: A BaseInformation instance containing the model metadata.
+        :param readme_path: If provided, the README will be written to this path.
+        :param version: '0' for old format, '1' for new format. If None, auto-detection is attempted.
+        :return: The generated README text (if readme_path is None).
+        """
+        d = data.as_dict()
+        if version is None:
+            # Auto-detect based on the presence of keys specific to the new format.
+            if "Output Columns" in d or "Model Incorporation Date" in d:
+                version = "1"
+            else:
+                version = "0"
+        if version == "0":
+            return self.write_information_0(data, readme_path)
+        elif version == "1":
+            return self.write_information_1(data, readme_path)
+        else:
+            raise ValueError("Unknown version specified for README generation.")
 
 
 class ReadmeUpdater:

--- a/.github/scripts/airtableops.py
+++ b/.github/scripts/airtableops.py
@@ -320,6 +320,8 @@ class ReadmeMetadata:
             text += "- **Deployment:** {0}\n".format(d.get("Deployment"))
         if d.get("Incorporation Quarter"):
             text += "- **Incorporation Quarter:** {0}\n".format(d.get("Incorporation Quarter"))
+        if d.get("Incorporation Date"):
+            text += "- **Incorporation Date:** {0}\n".format(d.get("Incorporation Date"))    
         if d.get("Incorporation Year"):
             text += "- **Incorporation Year:** {0}\n".format(d.get("Incorporation Year"))
         text += "\n"

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1042,7 +1042,7 @@ class BaseInformation(ErsiliaBase):
         """
         if type(new_publication_year) is not int:
             raise PublicationYearBaseInformationError
-        if new_publication_year < 1900 or new_publication_year > datetime.date.today().year:
+        if new_publication_year < 1900 or new_publication_year > datetime.today("Y"):
             raise PublicationBaseInformationError
         self._publication_year = new_publication_year
 
@@ -1605,8 +1605,8 @@ class BaseInformation(ErsiliaBase):
             "Title": self.title,
             "Description": self.description,
             "Mode": self.mode,
-            # "Source": self.source,
-            # "Source Type": self.source_type,
+            "Source": self.source,
+            "Source Type": self.source_type,
             "Input": self.input,
             "Input Shape": self.input_shape,
             # "Input Dimension": self.input_dimension,
@@ -1660,9 +1660,8 @@ class BaseInformation(ErsiliaBase):
         self._assign("status", "Status", data)
         self._assign("title", "Title", data)
         self._assign("description", "Description", data)
-        self._assign("mode", "Mode", data)
-        # self._assign("source", "Source", data)
-        # self._assign("source_type", "Source Type", data)
+        self._assign("source", "Source", data)
+        self._assign("source_type", "Source Type", data)
         self._assign("input", "Input", data)
         self._assign("input_shape", "Input Shape", data)
         # self._assign("input_dimension", "Input Dimension", data)

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -192,11 +192,13 @@ class BaseInformation(ErsiliaBase):
         self._license = None
         self._contributor = None
         self._incorporation_date = None
+        self._incorporation_year = None
         self._dockerhub = None
         self._docker_architecture = None
         self._s3 = None
         self._source = None
         self._source_type = None
+        self._image_size = None
         self._model_size_mb = None
         self._environment_size_mb = None
         self._image_size_mb = None
@@ -205,6 +207,7 @@ class BaseInformation(ErsiliaBase):
         self._computational_performance_hund = None
         self._pack_method = None
         self._deployment = None
+        self._biomodel_annotation = None
 
     def _is_valid_url(self, url_string: str) -> bool:
         result = validators.url(url_string)
@@ -1624,78 +1627,6 @@ class BaseInformation(ErsiliaBase):
         self._biomodel_annotation = value
 
     @property
-    def runtime(self):
-        """
-        Get the runtime information for the model.
-
-        Returns
-        -------
-        str
-            The model runtime information.
-        """
-        return self._runtime
-
-    @runtime.setter
-    def runtime(self, value):
-        """
-        Set the runtime information for the model.
-
-        Parameters
-        ----------
-        value : str
-            The new runtime information.
-        """
-        self._runtime = value
-
-    @property
-    def secrets(self):
-        """
-        Get the model secrets information.
-
-        Returns
-        -------
-        str
-            The secrets associated with the model.
-        """
-        return self._secrets
-
-    @secrets.setter
-    def secrets(self, value):
-        """
-        Set the model secrets information.
-
-        Parameters
-        ----------
-        value : str
-            The new secrets information.
-        """
-        self._secrets = value
-
-    @property
-    def incorporation_quarter(self):
-        """
-        Get the incorporation quarter of the model.
-
-        Returns
-        -------
-        str
-            The quarter in which the model was incorporated.
-        """
-        return self._incorporation_quarter
-
-    @incorporation_quarter.setter
-    def incorporation_quarter(self, value):
-        """
-        Set the incorporation quarter of the model.
-
-        Parameters
-        ----------
-        value : str
-            The new incorporation quarter.
-        """
-        self._incorporation_quarter = value
-
-    @property
     def incorporation_year(self):
         """
         Get the incorporation year of the model.
@@ -1817,10 +1748,7 @@ class BaseInformation(ErsiliaBase):
             "Docker Architecture": self.docker_architecture,
             "S3": self.s3,
             "Biomodel Annotation": self.biomodel_annotation,
-            "Runtime": self.runtime,
-            "Secrets": self.secrets,
             "Deployment": self.deployment,
-            "Incorporation Quarter": self.incorporation_quarter,
             "Incorporation Year": self.incorporation_year,
             "Environment Size": self.environment_size,
             "Image Size": self.image_size,
@@ -1893,10 +1821,7 @@ class BaseInformation(ErsiliaBase):
         self._assign("docker_architecture", "Docker Architecture", data)
         self._assign("s3", "S3", data)
         self._assign("biomodel_annotation", "Biomodel Annotation", data)
-        self._assign("runtime", "Runtime", data)
-        self._assign("secrets", "Secrets", data)
         self._assign("deployment", "Deployment", data)
-        self._assign("incorporation_quarter", "Incorporation Quarter", data)
         self._assign("incorporation_year", "Incorporation Year", data)
         # self._assign("model_size_mb", "Model Size", data)
         # self._assign("environment_size", "Environment Size", data)

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 
+# from datetime import datetime
 import validators
 
 try:

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1,5 +1,5 @@
-import datetime
 import os
+from datetime import datetime
 
 import validators
 
@@ -16,7 +16,6 @@ from ...utils.exceptions_utils.base_information_exceptions import (
     ComputationalPerformanceHundredBaseInformationError,
     ComputationalPerformanceOneBaseInformationError,
     ComputationalPerformanceTenBaseInformationError,
-    IncorporationDateBaseInformationError,
     ContributorBaseInformationError,
     DeploymentBaseInformationError,
     DescriptionBaseInformationError,
@@ -24,8 +23,10 @@ from ...utils.exceptions_utils.base_information_exceptions import (
     DockerhubBaseInformationError,
     EnvironmentSizeMbBaseInformationError,
     GithubBaseInformationError,
+    HostUrlBaseInformationError,
     IdentifierBaseInformationError,
     ImageSizeMbBaseInformationError,
+    IncorporationDateBaseInformationError,
     InputBaseInformationError,
     InputDimensionBaseInformationError,
     InputShapeBaseInformationError,
@@ -1042,7 +1043,10 @@ class BaseInformation(ErsiliaBase):
         """
         if type(new_publication_year) is not int:
             raise PublicationYearBaseInformationError
-        if new_publication_year < 1900 or new_publication_year > datetime.today("Y"):
+        if (
+            new_publication_year < 1900
+            or new_publication_year > datetime.date.today().year
+        ):
             raise PublicationBaseInformationError
         self._publication_year = new_publication_year
 
@@ -1527,7 +1531,12 @@ class BaseInformation(ErsiliaBase):
         incorporation_date : str
             The model contributing date.
         """
-        if new_incorporation_date != datetime.datetime.fromisoformat(str(new_incorporation_date)).date().isoformat():
+        if (
+            new_incorporation_date
+            != datetime.datetime.fromisoformat(str(new_incorporation_date))
+            .date()
+            .isoformat()
+        ):
             raise IncorporationDateBaseInformationError
         self._incorporation_date = new_incorporation_date
 
@@ -1589,6 +1598,205 @@ class BaseInformation(ErsiliaBase):
                 raise DeploymentBaseInformationError
         self._deployment = new_deployment
 
+    @property
+    def do_deployment(self):
+        """
+        Get the DigitalOcean deployment URL or value.
+
+        Returns
+        -------
+        str
+            The DO deployment value.
+        """
+        return self._do_deployment
+
+    @do_deployment.setter
+    def do_deployment(self, value):
+        """
+        Set the DigitalOcean deployment URL or value.
+
+        Parameters
+        ----------
+        value : str
+            The new DO deployment URL or value.
+        """
+        self._do_deployment = value
+
+    @property
+    def biomodel_annotation(self):
+        """
+        Get the biomodel annotation flag.
+
+        Returns
+        -------
+        str
+            The biomodel annotation information.
+        """
+        return self._biomodel_annotation
+
+    @biomodel_annotation.setter
+    def biomodel_annotation(self, value):
+        """
+        Set the biomodel annotation flag.
+
+        Parameters
+        ----------
+        value : str
+            The new biomodel annotation information.
+        """
+        self._biomodel_annotation = value
+
+    @property
+    def runtime(self):
+        """
+        Get the runtime information for the model.
+
+        Returns
+        -------
+        str
+            The model runtime information.
+        """
+        return self._runtime
+
+    @runtime.setter
+    def runtime(self, value):
+        """
+        Set the runtime information for the model.
+
+        Parameters
+        ----------
+        value : str
+            The new runtime information.
+        """
+        self._runtime = value
+
+    @property
+    def secrets(self):
+        """
+        Get the model secrets information.
+
+        Returns
+        -------
+        str
+            The secrets associated with the model.
+        """
+        return self._secrets
+
+    @secrets.setter
+    def secrets(self, value):
+        """
+        Set the model secrets information.
+
+        Parameters
+        ----------
+        value : str
+            The new secrets information.
+        """
+        self._secrets = value
+
+    @property
+    def incorporation_quarter(self):
+        """
+        Get the incorporation quarter of the model.
+
+        Returns
+        -------
+        str
+            The quarter in which the model was incorporated.
+        """
+        return self._incorporation_quarter
+
+    @incorporation_quarter.setter
+    def incorporation_quarter(self, value):
+        """
+        Set the incorporation quarter of the model.
+
+        Parameters
+        ----------
+        value : str
+            The new incorporation quarter.
+        """
+        self._incorporation_quarter = value
+
+    @property
+    def incorporation_year(self):
+        """
+        Get the incorporation year of the model.
+
+        Returns
+        -------
+        int
+            The year in which the model was incorporated.
+        """
+        return self._incorporation_year
+
+    @incorporation_year.setter
+    def incorporation_year(self, value):
+        """
+        Set the incorporation year of the model.
+
+        Parameters
+        ----------
+        value : int
+            The new incorporation year.
+        """
+        self._incorporation_year = value
+
+    @property
+    def image_size(self):
+        """
+        Get the image size of the model.
+
+        Returns
+        -------
+        str
+            The size of the model image.
+        """
+        return self._image_size
+
+    @image_size.setter
+    def image_size(self, value):
+        """
+        Set the image size of the model.
+
+        Parameters
+        ----------
+        value : str
+            The new image size.
+        """
+        self._image_size = value
+
+    @property
+    def host_url(self):
+        """
+        Get the model host URL.
+
+        Returns
+        -------
+        str
+            The model host URL.
+        """
+        return self.host_url
+
+    @host_url.setter
+    def host_url(self, value):
+        """
+        Set the model host URL.
+
+        Parameters
+        ----------
+        value : str
+            The new host URL.
+
+        Raises
+        ------
+        HostUrlBaseInformationError
+            If the host URL is provided and does not start with 'http'.
+        """
+        if value and not value.startswith("http"):
+            raise HostUrlBaseInformationError
+        self._host_url = value
+
     def as_dict(self):
         """
         Convert the model information to a dictionary.
@@ -1611,35 +1819,41 @@ class BaseInformation(ErsiliaBase):
             "Input Shape": self.input_shape,
             # "Input Dimension": self.input_dimension,
             "Task": self.task,
-            # "Subtask": self.subtask,
-            # "Biomedical Area": self.biomedical_area,
-            # "Target organism": self.target_organism,
+            "Subtask": self.subtask,
+            "Biomedical Area": self.biomedical_area,
+            "Target Organism": self.target_organism,
             "Output": self.output,
             "Output Type": self.output_type,
             "Output Shape": self.output_shape,
-            # "Output Dimension": self.output_dimension,
-            # "Output Consistency": self.output_consistency,
+            "Output Dimension": self.output_dimension,
+            "Output Consistency": self.output_consistency,
             "Interpretation": self.interpretation,
             "Tag": self.tag,
             "Publication": self.publication,
-            # "Publication Type": self.publication_type,
-            # "Publication Year": self.publication_year,
+            "Publication Type": self.publication_type,
+            "Publication Year": self.publication_year,
             "Source Code": self.source_code,
             "License": self.license,
             "Contributor": self.contributor,
-            # "Incorporation Date": self.incorporation_date,
+            "incorporation_date": self.incorporation_date,
             "DockerHub": self.dockerhub,
             "Docker Architecture": self.docker_architecture,
             "S3": self.s3,
-            # "Model Size": self.model_size_mb,
-            # "Environment Size": self.environment_size,
-            # "Image Size": self.image_size_mb,
-            # "Computational Performance 1": self.computational_performance_one,
-            # "Computational Performance 10": self.computational_performance_ten,
-            # "Computational Performance 100": self.computational_performance_hund,
-            # "Pack Method": self.pack_method,
-            # "Deployment": self.deployment,
+            "DO Deployment": self.do_deployment,
+            "Biomodel Annotation": self.biomodel_annotation,
+            "Runtime": self.runtime,
+            "Secrets": self.secrets,
+            "Deployment": self.deployment,
+            "Incorporation Quarter": self.incorporation_quarter,
+            "Incorporation Year": self.incorporation_year,
+            "Environment Size": self.environment_size,
+            "Image Size": self.image_size,
+            "Computational Performance 1": self.computational_performance_one,
+            "Computational Performance 10": self.computational_performance_ten,
+            "Computational Performance 100": self.computational_performance_hund,
+            "Docker Pack Method": self.pack_method,
         }
+
         data = dict((k, v) for k, v in data.items() if v is not None)
         return data
 
@@ -1655,30 +1869,46 @@ class BaseInformation(ErsiliaBase):
         data : dict
             The model information as a dictionary.
         """
+        if "Target Organism" in data:
+            raw = data["Target Organism"]
+            if isinstance(raw, str):
+                data["Target Organism"] = [
+                    item.strip() for item in raw.split(",") if item.strip()
+                ]
+
+        if "Data Architecture" in data:
+            raw = data["Data Architecture"]
+            if isinstance(raw, str):
+                data["Data Architecture"] = [
+                    item.strip() for item in raw.split(",") if item.strip()
+                ]
+
         self._assign("identifier", "Identifier", data)
         self._assign("slug", "Slug", data)
         self._assign("status", "Status", data)
         self._assign("title", "Title", data)
         self._assign("description", "Description", data)
+        self._assign("mode", "Mode", data)
         self._assign("source", "Source", data)
         self._assign("source_type", "Source Type", data)
         self._assign("input", "Input", data)
         self._assign("input_shape", "Input Shape", data)
         # self._assign("input_dimension", "Input Dimension", data)
         self._assign("task", "Task", data)
-        # self._assign("subtask", "Subtask", data)
-        # self._assign("biomedical_area", "Biomedical Area", data)
-        # self._assign("target_organism", "Target Organism", data)
+        self._assign("subtask", "Subtask", data)
+        self._assign("biomedical_area", "Biomedical Area", data)
+        self._assign("target_organism", "Target Organism", data)
+        # self._assign("github", "GitHub", data)
         self._assign("output", "Output", data)
         self._assign("output_type", "Output Type", data)
         self._assign("output_shape", "Output Shape", data)
-        # self._assign("output_dimension", "Output Dimension", data)
-        # self._assign("output_consistency", "Output Consistency", data)
+        self._assign("output_dimension", "Output Dimension", data)
+        self._assign("output_consistency", "Output Consistency", data)
         self._assign("interpretation", "Interpretation", data)
         self._assign("tag", "Tag", data)
         self._assign("publication", "Publication", data)
-        # self._assign("publication_type", "Publication Type", data)
-        # self._assign("publication_year", "Publication Year", data)
+        self._assign("publication_type", "Publication Type", data)
+        self._assign("publication_year", "Publication Year", data)
         self._assign("source_code", "Source Code", data)
         self._assign("license", "License", data)
         self._assign("contributor", "Contributor", data)
@@ -1686,6 +1916,13 @@ class BaseInformation(ErsiliaBase):
         self._assign("dockerhub", "DockerHub", data)
         self._assign("docker_architecture", "Docker Architecture", data)
         self._assign("s3", "S3", data)
+        self._assign("do_deployment", "DO Deployment", data)
+        self._assign("biomodel_annotation", "Biomodel Annotation", data)
+        self._assign("runtime", "Runtime", data)
+        self._assign("secrets", "Secrets", data)
+        self._assign("deployment", "Deployment", data)
+        self._assign("incorporation_quarter", "Incorporation Quarter", data)
+        self._assign("incorporation_year", "Incorporation Year", data)
         # self._assign("model_size_mb", "Model Size", data)
         # self._assign("environment_size", "Environment Size", data)
         # self._assign("image_size_mb", "Image Size", data)
@@ -1698,5 +1935,4 @@ class BaseInformation(ErsiliaBase):
         # self._assign(
         #     "computational_performance_hund", "Computational Performance 100", data
         # )
-        # self._assign("pack_method", "Pack Method", data)
-        # self._assign("deployment", "Deployment", data)
+        # self._assign("pack_method", "Docker Pack Method", data)

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1600,30 +1600,6 @@ class BaseInformation(ErsiliaBase):
         self._deployment = new_deployment
 
     @property
-    def do_deployment(self):
-        """
-        Get the DigitalOcean deployment URL or value.
-
-        Returns
-        -------
-        str
-            The DO deployment value.
-        """
-        return self._do_deployment
-
-    @do_deployment.setter
-    def do_deployment(self, value):
-        """
-        Set the DigitalOcean deployment URL or value.
-
-        Parameters
-        ----------
-        value : str
-            The new DO deployment URL or value.
-        """
-        self._do_deployment = value
-
-    @property
     def biomodel_annotation(self):
         """
         Get the biomodel annotation flag.
@@ -1840,7 +1816,6 @@ class BaseInformation(ErsiliaBase):
             "DockerHub": self.dockerhub,
             "Docker Architecture": self.docker_architecture,
             "S3": self.s3,
-            "DO Deployment": self.do_deployment,
             "Biomodel Annotation": self.biomodel_annotation,
             "Runtime": self.runtime,
             "Secrets": self.secrets,
@@ -1917,7 +1892,6 @@ class BaseInformation(ErsiliaBase):
         self._assign("dockerhub", "DockerHub", data)
         self._assign("docker_architecture", "Docker Architecture", data)
         self._assign("s3", "S3", data)
-        self._assign("do_deployment", "DO Deployment", data)
         self._assign("biomodel_annotation", "Biomodel Annotation", data)
         self._assign("runtime", "Runtime", data)
         self._assign("secrets", "Secrets", data)

--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 
-# from datetime import datetime
 import validators
 
 try:
@@ -193,6 +192,7 @@ class BaseInformation(ErsiliaBase):
         self._contributor = None
         self._incorporation_date = None
         self._incorporation_year = None
+        self._incorporation_quarter = None
         self._dockerhub = None
         self._docker_architecture = None
         self._s3 = None
@@ -1047,10 +1047,7 @@ class BaseInformation(ErsiliaBase):
         """
         if type(new_publication_year) is not int:
             raise PublicationYearBaseInformationError
-        if (
-            new_publication_year < 1900
-            or new_publication_year > datetime.date.today().year
-        ):
+        if new_publication_year < 1900 or new_publication_year > datetime.today().year:
             raise PublicationBaseInformationError
         self._publication_year = new_publication_year
 
@@ -1535,14 +1532,12 @@ class BaseInformation(ErsiliaBase):
         incorporation_date : str
             The model contributing date.
         """
-        if (
-            new_incorporation_date
-            != datetime.datetime.fromisoformat(str(new_incorporation_date))
-            .date()
-            .isoformat()
-        ):
+        try:
+            parsed_date = datetime.strptime(new_incorporation_date, "%d/%m/%Y").date()
+            iso_date = parsed_date.isoformat()
+        except Exception:
             raise IncorporationDateBaseInformationError
-        self._incorporation_date = new_incorporation_date
+        self._incorporation_date = iso_date
 
     @property
     def contributor(self):
@@ -1651,6 +1646,30 @@ class BaseInformation(ErsiliaBase):
         self._incorporation_year = value
 
     @property
+    def incorporation_quarter(self):
+        """
+        Get the incorporation quarter of the model.
+
+        Returns
+        -------
+        int
+            The quarter in which the model was incorporated.
+        """
+        return self._incorporation_quarter
+
+    @incorporation_quarter.setter
+    def incorporation_quarter(self, value):
+        """
+        Set the incorporation quarter of the model.
+
+        Parameters
+        ----------
+        value : int
+            The new incorporation quarter.
+        """
+        self._incorporation_quarter = value
+
+    @property
     def image_size(self):
         """
         Get the image size of the model.
@@ -1723,33 +1742,48 @@ class BaseInformation(ErsiliaBase):
             "Mode": self.mode,
             "Source": self.source,
             "Source Type": self.source_type,
-            "Input": self.input,
+            "Input": ", ".join(self.input)
+            if isinstance(self.input, list)
+            else self.input,
             "Input Shape": self.input_shape,
             # "Input Dimension": self.input_dimension,
-            "Task": self.task,
-            "Subtask": self.subtask,
-            "Biomedical Area": self.biomedical_area,
-            "Target Organism": self.target_organism,
+            "Task": ", ".join(self.task) if isinstance(self.task, list) else self.task,
+            "Subtask": ", ".join(self.subtask)
+            if isinstance(self.subtask, list)
+            else self.subtask,
+            "Biomedical Area": ", ".join(self.biomedical_area)
+            if isinstance(self.biomedical_area, list)
+            else self.biomedical_area,
+            "Target Organism": ", ".join(self.target_organism)
+            if isinstance(self.target_organism, list)
+            else self.target_organism,
             "Output": self.output,
-            "Output Type": self.output_type,
+            "Output Type": ", ".join(self.output_type)
+            if isinstance(self.output_type, list)
+            else self.output_type,
             "Output Shape": self.output_shape,
             "Output Dimension": self.output_dimension,
             "Output Consistency": self.output_consistency,
             "Interpretation": self.interpretation,
-            "Tag": self.tag,
+            "Tag": ", ".join(self.tag) if isinstance(self.tag, list) else self.tag,
             "Publication": self.publication,
             "Publication Type": self.publication_type,
             "Publication Year": self.publication_year,
             "Source Code": self.source_code,
             "License": self.license,
             "Contributor": self.contributor,
-            "incorporation_date": self.incorporation_date,
+            "Incorporation Date": self.incorporation_date,
             "DockerHub": self.dockerhub,
-            "Docker Architecture": self.docker_architecture,
+            "Docker Architecture": ", ".join(self.docker_architecture)
+            if isinstance(self.docker_architecture, list)
+            else self.docker_architecture,
             "S3": self.s3,
             "Biomodel Annotation": self.biomodel_annotation,
-            "Deployment": self.deployment,
+            "Deployment": ", ".join(self.deployment)
+            if isinstance(self.deployment, list)
+            else self.deployment,
             "Incorporation Year": self.incorporation_year,
+            "Incorporation Quarter": self.incorporation_quarter,
             "Environment Size": self.environment_size,
             "Image Size": self.image_size,
             "Computational Performance 1": self.computational_performance_one,
@@ -1816,13 +1850,14 @@ class BaseInformation(ErsiliaBase):
         self._assign("source_code", "Source Code", data)
         self._assign("license", "License", data)
         self._assign("contributor", "Contributor", data)
-        # self._assign("incorporation_date", "Incorporation Date", data)
+        self._assign("incorporation_date", "Incorporation Date", data)
         self._assign("dockerhub", "DockerHub", data)
         self._assign("docker_architecture", "Docker Architecture", data)
         self._assign("s3", "S3", data)
         self._assign("biomodel_annotation", "Biomodel Annotation", data)
         self._assign("deployment", "Deployment", data)
         self._assign("incorporation_year", "Incorporation Year", data)
+        self._assign("incorporation_quarter", "Incorporation Quarter", data)
         # self._assign("model_size_mb", "Model Size", data)
         # self._assign("environment_size", "Environment Size", data)
         # self._assign("image_size_mb", "Image Size", data)

--- a/ersilia/hub/content/metadata/target_organism.txt
+++ b/ersilia/hub/content/metadata/target_organism.txt
@@ -4,5 +4,30 @@ Rat norvegicus
 Plasmodium falciparum
 Plasmodium vivax
 Mycobacterium tuberculosis
-Plasmodium falciparum
+Fast-acid bacteria
+Fungi
+Gram-negative bacteria
+Gram-positive bacteria
+Schistosoma mansoni
+Madurella mycetomatis
+Burkholderia cenocepacia
+Acinetobacter baumannii
+Neisseria gonorrhoeae
+Staphylococcus aureus
+Pseudomonas aeruginosa
+Enterobacteriaceae spp
+Enterococcus faecium
+Helicobacter pylori
+Campylobacter spp
+Salmonella spp
+Streptococcus pneumoniae
+Haemophilus influenzae
+Shigella spp
+SARS-CoV-2
+SARS-CoV-1
+MERS
+Hepatitis B virus
+Hepatitis C virus
+HIV
+Ebola virus
 Not Applicable

--- a/ersilia/hub/content/metadata/target_organism.txt
+++ b/ersilia/hub/content/metadata/target_organism.txt
@@ -4,30 +4,5 @@ Rat norvegicus
 Plasmodium falciparum
 Plasmodium vivax
 Mycobacterium tuberculosis
-Fast-acid bacteria
-Fungi
-Gram-negative bacteria
-Gram-positive bacteria
-Schistosoma mansoni
-Madurella mycetomatis
-Burkholderia cenocepacia
-Acinetobacter baumannii
-Neisseria gonorrhoeae
-Staphylococcus aureus
-Pseudomonas aeruginosa
-Enterobacteriaceae spp
-Enterococcus faecium
-Helicobacter pylori
-Campylobacter spp
-Salmonella spp
-Streptococcus pneumoniae
-Haemophilus influenzae
-Shigella spp
-SARS-CoV-2
-SARS-CoV-1
-MERS
-Hepatitis B virus
-Hepatitis C virus
-HIV
-Ebola virus
+Plasmodium falciparum
 Not Applicable

--- a/ersilia/utils/exceptions_utils/base_information_exceptions.py
+++ b/ersilia/utils/exceptions_utils/base_information_exceptions.py
@@ -369,3 +369,10 @@ class DeploymentBaseInformationError(ErsiliaError):
             ", ".join(_read_default_fields("Deployment"))
         )
         ErsiliaError.__init__(self, self.message, self.hints)
+
+
+class HostUrlBaseInformationError(ErsiliaError):
+    def __init__(self):
+        self.message = "Wrong host URL"
+        self.hints = "The host URL must be a valid URL starting with 'http'."
+        ErsiliaError().__init__(self.message, self.hints)

--- a/ersilia/utils/exceptions_utils/base_information_exceptions.py
+++ b/ersilia/utils/exceptions_utils/base_information_exceptions.py
@@ -1,5 +1,6 @@
 import os
 
+# import sys
 from ...default import AIRTABLE_MODEL_HUB_VIEW_URL
 from .exceptions import ErsiliaError
 


### PR DESCRIPTION

Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [X] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally?

**Description**

This pull request updates the README file generation and parsing to support both the old and new formats while maintaining backward compatibility.

Update README File Generation

1. Modify the ReadmeMetadata Class (in .github/scripts/airtableops.py):

- Implement two methods:

`write_information_0`: Generates the README in the old format.
`write_information_1`: Generates the README in the new format (as detailed in our provided example).
Update the existing `write_information` method to detect the type of metadata (old and new) and delegate to the appropriate method.

2. Update README File Parsing


- Modify the ReadmeCard Class (in hub/content/card.py):

Create two parsing classes:
`ReadmeCardVersion0` for the old README format.
`ReadmeCardVersion1` for the new README format.
Develop an overarching resolver ( `ReadmeCardResolver`) that examines a` README` file for specific markers and selects the correct parser accordingly.
Changes to be made

Refactor the README generation logic by adding `write_information_0` and `write_information_1` methods in the `ReadmeMetadata `class.
Refactor the README parsing logic by splitting the functionality into ReadmeCardVersion0 and ReadmeCardVersion1, and implement a resolver to automatically choose between them based on the file content.


Is this pull request related to any open issue? If yes, replace issueID below with the issue ID

Fixes #1555 