### PR TITLE
Improve TOC navigation in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,19 @@ Ersilia is an open project and everyone is welcome to contribute to it. Please r
 
 ## Table of Contents
 
-- [Code of Conduct 🤝](#code-of-conduct-)
-- [Where to Start? 🧭](#where-to-start-🧭)
-- [How to Contribute 📜](#how-to-contribute-)
-- [Create a new Issue 🚀](#create-a-new-issue-)
-- [Contribution Workflow 🔄](#contribution-workflow-)
-- [Other Contributing Suggestions 💡](#other-contributing-suggestions-)
-- [I still have questions ❓](#i-still-have-questions-)
+- [Code of Conduct 🤝](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#code-of-conduct-)
+- [Where to Start? 🧭](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#where-to-start-)
+- [How to Contribute 📜](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#how-to-contribute-)
+- [Create a new Issue 🚀](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#create-a-new-issue-)
+- [Contribution Workflow 🔄](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#contribution-workflow-)
+- [Other Contributing Suggestions 💡](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#other-contributing-suggestions-)
+- [I still have questions ❓](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md#other-contributing-suggestions-)
 
-## Code of Conduct 🤝
+## Code of Conduct 🤝 [`⇧`](#table-of-contents)
 
 We aspire to create a welcoming and safe environment for collaboration on this project and ask all contributors to do the same. Help us keep Ersilia open and inclusive. Please read and follow our [Code of Conduct](https://github.com/ersilia-os/ersilia/blob/master/CODE_OF_CONDUCT.md).
 
-## Where to Start? 🧭
+## Where to Start? 🧭 [`⇧`](#table-of-contents)
 
 The best place to start is by checking our issue tracker. Our issues have the following labels to guide contributors in their work:
 
@@ -30,11 +30,11 @@ The best place to start is by checking our issue tracker. Our issues have the fo
 | Enhancement      | Add a new feature                                               |
 | Documentation    | Issues related to the project's documentation                   |
 
-## How to Contribute 📜
+## How to Contribute 📜 [`⇧`](#table-of-contents)
 
 If this is the first time contributing to an Open Source project, read a bit about [How to Contribute to An Open Source Project on Github](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github) and [Collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests). If you land here during the Outreachy contribution period, please look for the appropriate guidelines in our [documentation](https://ersilia.gitbook.io/ersilia-book/contributors/internships).
 
-## Create a new Issue 🚀
+## Create a new Issue 🚀 [`⇧`](#table-of-contents)
 
 The issue tracking avoids duplications and prevents different contributors working on the same feature separately, so please make sure to create a new issue with the appropriate labels before jumping on coding! You can create the following issue types:
 
@@ -47,7 +47,7 @@ The issue tracking avoids duplications and prevents different contributors worki
 |🐅 Epic            | Create a new Epic                               |
 |🐈 Task            | Create a new Task                               |
 
-## Contribution Workflow 🔄
+## Contribution Workflow 🔄 [`⇧`](#table-of-contents)
 
 Once you have identified an issue to tackle, follow the next steps:
 
@@ -58,13 +58,13 @@ Once you have identified an issue to tackle, follow the next steps:
 5. Once the PR has been merged, delete your fork of the repository. Our Git-LFS quota also takes into account forks, so having unused forks sitting around is eating up our space in Git LFS. Thanks for taking care of the community.
 6. Look for a new issue to work on!
 
-## Other Contributing Suggestions 💡
+## Other Contributing Suggestions 💡 [`⇧`](#table-of-contents)
 
 * Support already existing contributors with comments on the issues they might be tackling
 * Create new issues for bug reports or feature enhancements using the appropriate templates (even if the issue is out of scope for you, it might be a good job for another contributor)
 * Suggest new models to the Ersilia Model Hub using an issue or via our online [form](https://airtable.com/shrmEcwwxpb21TEVw)
 * Documentation-related enhancements are very welcome, please work on them by opening a new issue
 
-## I still have questions ❓
+## I still have questions ❓ [`⇧`](#table-of-contents)
 
 If you need some more guidance, open an issue and get support from the community!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 4. [License and citation](https://github.com/ersilia-os/ersilia#license-and-citation)
 5. [About us](https://github.com/ersilia-os/ersilia#about-us)
 
-## Project Description
+## Project Description [`⇧`](#table-of-contents)
 
 The [Ersilia Model Hub](https://ersilia.io) is a unified platform of pre-trained AI/ML models for 🦠 infectious and neglected disease research. Our mission is to offer an open-source, 🛠 low-code solution that provides seamless access to AI/ML models for 💊 drug discovery. Models housed in our hub come from two sources:
 
@@ -27,7 +27,7 @@ The [Ersilia Model Hub](https://ersilia.io) is a unified platform of pre-trained
 
 You can read more about the project in the [Ersilia Book](https://ersilia.gitbook.io/ersilia-book/) and browse available models in the [Ersilia Model Hub](https://ersilia.io/model-hub/).
 
-## Quick Start Guide
+## Quick Start Guide [`⇧`](#table-of-contents)
 
 Please check the package requirements in the [Installation Guide](https://ersilia.gitbook.io/ersilia-book/quick-start/installation). The following steps are a quick start guide to using Ersilia.
 
@@ -101,7 +101,7 @@ For Python versions 3.12, Ersilia explicitly installs the setuptools library dur
 
 Note: If you are using Python 3.12, you don’t need to take any manual action. The Ersilia CLI automatically handles this by installing setuptools as part of the setup process.
 
-## Contribute
+## Contribute [`⇧`](#table-of-contents)
 
 The Ersilia Model Hub is a Free, Open Source Software and we highly value new contributors. There are several ways in which you can contribute to the project:
 
@@ -152,7 +152,7 @@ If you want to incorporate a new model in the platform, open a new issue using t
 
 After submitting your model request via an issue (suggested), an Ersilia maintainer will review your request. If they approve your request, a new model respository will be created for you to fork and use! There is a [demo repository](https://github.com/ersilia-os/eos-demo) explaining the steps one-by-one.
 
-## License and Citation
+## License and Citation [`⇧`](#table-of-contents)
 
 This repository is open-sourced under the [GPL-3 License](https://github.com/ersilia-os/ersilia/blob/master/LICENSE).
 Please [cite us](https://github.com/ersilia-os/ersilia/blob/master/CITATION.cff) if you use it!
@@ -170,7 +170,7 @@ The Ersilia Model Hub is used in a number of scientific projects. Read more abou
 - [Offensperger et al, Science, 2024](https://www.science.org/doi/10.1126/science.adk5864)
 - [Turon et al, ACS Med Chem Lett, 2024](https://doi.org/10.1021/acsmedchemlett.4c00131)
 
-## About Us
+## About Us [`⇧`](#table-of-contents)
 
 The [Ersilia Open Source Initiative](https://ersilia.io) is a Non Profit Organization with the mission is to equip labs, universities and clinics in LMIC with AI/ML tools for infectious disease research.
 [Help us](https://www.ersilia.io/donate) achieve our mission!


### PR DESCRIPTION
…chors to headers

update README.md: add ⇧ anchors to headers for better navigation

Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


**Description**

This PR enhances navigation across both the `CONTRIBUTING.md` and `README.md` files by:

- Replacing local anchor links in `CONTRIBUTING.md`'s table of contents with full GitHub URLs, aligning it with the style used in `README.md`.
- Adding `⇧` return-to-top anchors next to each header in both files for smoother navigation.

This makes it easier to move around the documentation.
