### PR TITLE
Splunk monitoring including tracking country and use case

### DIFF
--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -52,10 +52,12 @@ def serve_cmd():
     )
     @click.option(
         "--tracking-use-case",
-        type=click.Choice(["local", "run"], case_sensitive=True),
+        type=click.Choice(
+            ["local", "self-service", "hosted", "test"], case_sensitive=True
+        ),
         required=False,
-        default="serve",
-        help="Tracking use case. Options: local, workflow, self-service, hosted, test",
+        default="local",
+        help="Tracking use case. Options: local, self-service, hosted, test",
     )
     @click.option(
         "--enable-local-cache/--disable-local-cache", is_flag=True, default=True
@@ -64,7 +66,7 @@ def serve_cmd():
     @click.option("--cloud-cache-only", is_flag=True, default=False)
     @click.option("--cache-only", is_flag=True, default=False)
     @click.option(
-        "--max-cache-memory-frac", "maxmemory", type=click.FLOAT, default=None
+        "--max-cache-memory-frac", "max_memory", type=click.FLOAT, default=None
     )
     def serve(
         model,
@@ -75,7 +77,7 @@ def serve_cmd():
         local_cache_only,
         cloud_cache_only,
         cache_only,
-        maxmemory,
+        max_memory,
     ):
         output_source = None
         cache_status = "Disabled"
@@ -95,9 +97,9 @@ def serve_cmd():
             output_source=output_source,
             preferred_port=port,
             cache=enable_local_cache,
-            maxmemory=maxmemory,
+            maxmemory=max_memory,
         )
-        redis_setup = SetupRedis(enable_local_cache, maxmemory)
+        redis_setup = SetupRedis(enable_local_cache, max_memory)
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
 
@@ -147,7 +149,7 @@ def serve_cmd():
         echo("")
         echo(":chart_increasing: Tracking:", fg="blue")
         if track:
-            echo("   - Enabled", fg="green")
+            echo("   - Enabled ({0})".format(tracking_use_case), fg="green")
         else:
             echo("   - Disabled", fg="red")
 

--- a/ersilia/cli/commands/serve.py
+++ b/ersilia/cli/commands/serve.py
@@ -51,6 +51,13 @@ def serve_cmd():
         default=False,
     )
     @click.option(
+        "--tracking-use-case",
+        type=click.Choice(["local", "run"], case_sensitive=True),
+        required=False,
+        default="serve",
+        help="Tracking use case. Options: local, workflow, self-service, hosted, test",
+    )
+    @click.option(
         "--enable-local-cache/--disable-local-cache", is_flag=True, default=True
     )
     @click.option("--local-cache-only", is_flag=True, default=False)
@@ -63,6 +70,7 @@ def serve_cmd():
         model,
         port,
         track,
+        tracking_use_case,
         enable_local_cache,
         local_cache_only,
         cloud_cache_only,
@@ -92,6 +100,11 @@ def serve_cmd():
         redis_setup = SetupRedis(enable_local_cache, maxmemory)
         if not mdl.is_valid():
             ModelNotFound(mdl).echo()
+
+        if track:
+            track = tracking_use_case
+        else:
+            track = None
 
         mdl.serve(track_runs=track)
         if mdl.url is None:

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -647,7 +647,7 @@ class ErsiliaModel(ErsiliaBase):
         pass  # TODO Implement whenever this is necessary
 
     @throw_ersilia_exception()
-    def serve(self, track_runs=False):
+    def serve(self, track_runs=None):
         """
         Serve the model by starting the necessary services.
 
@@ -657,14 +657,14 @@ class ErsiliaModel(ErsiliaBase):
 
         Parameters
         ----------
-        track_runs : bool, optional
-            Whether to track runs, by default False.
+        track_runs : str, optional
+            Whether to track runs, by default is None (i.e. do not track).
         """
         self.logger.debug("Starting serve")
         self.session = Session(config_json=self.config_json)
         self.run_tracker = None
         self.track = False
-        if track_runs:
+        if track_runs is not None:
             if not isinstance(self.autoservice.service, PulledDockerImageService):
                 self.logger.warning(
                     "Tracking runs is currently only supported for Dockerized models"
@@ -673,7 +673,9 @@ class ErsiliaModel(ErsiliaBase):
             else:
                 self.track = True
                 self.run_tracker = RunTracker(
-                    model_id=self.model_id, config_json=self.config_json
+                    model_id=self.model_id,
+                    config_json=self.config_json,
+                    use_case=track_runs,
                 )
         self.setup()
         self.close()

--- a/ersilia/core/model.py
+++ b/ersilia/core/model.py
@@ -663,6 +663,7 @@ class ErsiliaModel(ErsiliaBase):
         self.logger.debug("Starting serve")
         self.session = Session(config_json=self.config_json)
         self.run_tracker = None
+        self.tracking_use_case = track_runs
         self.track = False
         if track_runs is not None:
             if not isinstance(self.autoservice.service, PulledDockerImageService):
@@ -683,6 +684,8 @@ class ErsiliaModel(ErsiliaBase):
         self.autoservice.serve()
         self.session.register_service_class(self.autoservice._service_class)
         self.session.register_output_source(self.output_source)
+        if self.track:
+            self.session.register_tracking_use_case(self.tracking_use_case)
         self.url = self.autoservice.service.url
         self.pid = self.autoservice.service.pid
         self.scl = self.autoservice._service_class
@@ -782,9 +785,12 @@ class ErsiliaModel(ErsiliaBase):
 
         # Init the run tracker
         if track_run:
-            self.logger.debug("Initializing the run trackers")
+            use_case = session.get_tracking_use_case()
+            self.logger.debug(
+                "Initializing the run trackers (use case {0})".format(use_case)
+            )
             self.run_tracker = RunTracker(
-                model_id=self.model_id, config_json=self.config_json
+                model_id=self.model_id, config_json=self.config_json, use_case=use_case
             )
         self.logger.info("Starting runner")
 

--- a/ersilia/core/session.py
+++ b/ersilia/core/session.py
@@ -128,6 +128,23 @@ class Session(ErsiliaBase):
         with open(self.session_file, "w") as f:
             json.dump(data, f, indent=4)
 
+    def register_tracking_use_case(self, use_case):
+        """
+        Register the tracking use case in the session.
+
+        This method updates the session data with the provided tracking use case.
+
+        Parameters
+        ----------
+        use_case : str
+            The tracking use case to register.
+        """
+        data = self.get()
+        data["tracking_use_case"] = use_case
+        with open(self.session_file, "w") as f:
+            json.dump(data, f, indent=4)
+        self.logger.debug("Registering tracking use case: {0}".format(use_case))
+
     def tracking_status(self):
         """
         Get the tracking status from the session.
@@ -144,6 +161,23 @@ class Session(ErsiliaBase):
             return None
         else:
             return data["track_runs"]
+
+    def get_tracking_use_case(self):
+        """
+        Get the tracking use case from the session.
+
+        This method retrieves the tracking use case from the session data.
+
+        Returns
+        -------
+        str or None
+            The tracking use case, or None if no session data is available.
+        """
+        data = self.get()
+        if data is None:
+            return None
+        else:
+            return data.get("tracking_use_case", None)
 
     def open(self, model_id, track_runs):
         """

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import uuid
+from datetime import datetime
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -417,6 +418,8 @@ class RunTracker(ErsiliaBase):
             "session_id": get_session_uuid(),
             "event_id": event_id,
             "country": country,
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "use_case": self.use_case.capitalize(),
             "model_id": self.model_id,
             "slug": metadata["Slug"],
             "task": metadata["Task"],

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -12,6 +12,7 @@ from ..io.output_logger import TabularResultLogger
 from ..utils.exceptions_utils.throw_ersilia_exception import throw_ersilia_exception
 from ..utils.exceptions_utils.tracking_exceptions import NoAWSCredentialsError
 from ..utils.session import get_session_dir, get_session_uuid
+from ..utils.system import SystemChecker
 from .base import ErsiliaBase
 
 TRACKING_BUCKET = "ersilia-models-runs"
@@ -124,8 +125,9 @@ class RunTracker(ErsiliaBase):
         Configuration in JSON format.
     """
 
-    def __init__(self, model_id, config_json):
+    def __init__(self, model_id, use_case, config_json):
         ErsiliaBase.__init__(self, config_json=config_json, credentials_json=None)
+        self.use_case = use_case
         self.aws_config = AwsConfig()
         self.time_start = None
         self.memory_usage_start = 0
@@ -340,6 +342,27 @@ class RunTracker(ErsiliaBase):
             return False
         return True
 
+    def get_country(self):
+        """
+        Get the country of the user.
+        This method uses retrieves the country information.
+        If the country information is not available, it defaults to 'Unknown'.
+
+        Returns
+        -------
+        str
+            The country of the user.
+        """
+        sc = SystemChecker()
+        country, _ = sc.get_country()
+        if country is None:
+            self.logger.warning(
+                "Unable to get country information. Defaulting to 'Unknown'."
+            )
+            country = "Unknown"
+        self.logger.debug("Country: {0}".format(country))
+        return country
+
     @throw_ersilia_exception()
     def create_event_data(self, event_id, input, output, metadata, time_seconds):
         """
@@ -386,11 +409,14 @@ class RunTracker(ErsiliaBase):
             + error_and_warning_info_console_log["warning_count"]
         )
 
+        country = self.get_country()
+
         result_summary = self.summarize_output(output)
 
         data = {
             "session_id": get_session_uuid(),
             "event_id": event_id,
+            "country": country,
             "model_id": self.model_id,
             "slug": metadata["Slug"],
             "task": metadata["Task"],

--- a/ersilia/utils/system.py
+++ b/ersilia/utils/system.py
@@ -1,5 +1,9 @@
 import os
 import platform
+import stat
+import tempfile
+
+from .terminal import run_command
 
 
 def is_inside_docker():
@@ -75,3 +79,66 @@ class SystemChecker(object):
             True if running inside a Docker container, False otherwise.
         """
         return is_inside_docker()
+
+    def get_country(self):
+        """
+        Get the country code of the system based on the IP address.
+
+        Returns
+        -------
+        tuple
+            The country of the system and its 3-character code (Country, Code).
+        """
+
+        bash_script = """#!/usr/bin/env bash
+
+        # Usage: ./geoip.sh [IP_ADDRESS]
+        IP="${1:-$(curl -s https://ifconfig.me)}"
+        RESP=$(curl -s "http://ip-api.com/json/${IP}")
+
+        # helper: extract the first JSON field value for a given key
+        #   args: $1 = JSON text, $2 = field name
+        get_field(){
+        # strip up to "<key>":"..."
+        local tmp="${1#*\\\"$2\\\":\\\"}"
+        # then strip everything after the closing quote
+        printf '%s' "${tmp%%\\\"*}"
+        }
+
+        status=$(get_field "$RESP" status)
+        if [[ "$status" != success ]]; then
+        msg=$(get_field "$RESP" message)
+        echo "Lookup failed: ${msg:-$status}" >&2
+        exit 1
+        fi
+
+        country=$(get_field "$RESP" country)
+        code=$(get_field "$RESP" countryCode)
+
+        echo "Country: $country"
+        echo "Code:    $code"
+        """
+
+        tmp_dir = tempfile.mkdtemp(prefix="ersilia-")
+        tmp_dir = os.getcwd()
+
+        with open(os.path.join(tmp_dir, "geoip.sh"), "w") as f:
+            f.write(bash_script)
+
+        os.chmod(
+            os.path.join(tmp_dir, "geoip.sh"),
+            stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR,
+        )
+
+        run_command(f"bash {tmp_dir}/geoip.sh > {tmp_dir}/geoip.txt")
+
+        with open(os.path.join(tmp_dir, "geoip.txt"), "r") as f:
+            text = f.read()
+            if "Country" in text:
+                country = text.split("Country: ")[1].rstrip().split("\n")[0]
+                code = text.split("Code:    ")[1].rstrip().split("\n")[0]
+            else:
+                country = "None"
+                code = "None"
+
+        return (country, code)

--- a/ersilia/utils/system.py
+++ b/ersilia/utils/system.py
@@ -120,7 +120,6 @@ class SystemChecker(object):
         """
 
         tmp_dir = tempfile.mkdtemp(prefix="ersilia-")
-        tmp_dir = os.getcwd()
 
         with open(os.path.join(tmp_dir, "geoip.sh"), "w") as f:
             f.write(bash_script)


### PR DESCRIPTION
This pull request introduces a new "tracking use case" feature to the `serve` command in the `ersilia` CLI, enhances tracking capabilities in the core model and session modules, and adds functionality for geographic data retrieval. The changes improve the flexibility and granularity of tracking, allowing users to specify use cases and collect additional metadata such as country information.

### Enhancements to the `serve` command:
* Added a new `--tracking-use-case` option to the `serve` command, allowing users to specify tracking contexts such as "local," "self-service," "hosted," or "test." This option integrates with the `track` flag to enable more granular tracking. (`ersilia/cli/commands/serve.py`, [[1]](diffhunk://#diff-bf2cb8d9ea55f818ef68bbb4c3ca35ea81e63f952c2277ca47eefd60b3b08b0eR53-R80) [[2]](diffhunk://#diff-bf2cb8d9ea55f818ef68bbb4c3ca35ea81e63f952c2277ca47eefd60b3b08b0eL90-R110) [[3]](diffhunk://#diff-bf2cb8d9ea55f818ef68bbb4c3ca35ea81e63f952c2277ca47eefd60b3b08b0eL137-R152)
* Updated variable naming for consistency, changing `maxmemory` to `max_memory` throughout the `serve` command. (`ersilia/cli/commands/serve.py`, [[1]](diffhunk://#diff-bf2cb8d9ea55f818ef68bbb4c3ca35ea81e63f952c2277ca47eefd60b3b08b0eR53-R80) [[2]](diffhunk://#diff-bf2cb8d9ea55f818ef68bbb4c3ca35ea81e63f952c2277ca47eefd60b3b08b0eL90-R110)

### Core model tracking improvements:
* Modified the `serve` method in `ersilia/core/model.py` to accept `track_runs` as a string (use case) instead of a boolean, and introduced logic to handle the new tracking use case. (`ersilia/core/model.py`, [[1]](diffhunk://#diff-f11c37b66cae27db19f6186c3c81be9de6e57ef05e4f47be27449806d435290aL650-R650) [[2]](diffhunk://#diff-f11c37b66cae27db19f6186c3c81be9de6e57ef05e4f47be27449806d435290aL660-R668) [[3]](diffhunk://#diff-f11c37b66cae27db19f6186c3c81be9de6e57ef05e4f47be27449806d435290aL676-R688)
* Enhanced the `RunTracker` class to include the `use_case` parameter, which is now incorporated into event data and metadata. (`ersilia/core/tracking.py`, [[1]](diffhunk://#diff-64965392109ab24f59cfd7848c73d61218fa4dc40aacca63b1e9e3a496fba5e4L127-R131) [[2]](diffhunk://#diff-64965392109ab24f59cfd7848c73d61218fa4dc40aacca63b1e9e3a496fba5e4R413-R422)

### Session tracking updates:
* Added methods `register_tracking_use_case` and `get_tracking_use_case` to the `Session` class, enabling the storage and retrieval of tracking use case information in session files. (`ersilia/core/session.py`, [[1]](diffhunk://#diff-dd8374eb1e491690debbe04fe71354ea54d903ac327aeebfd3dfb09bf0f939f3R131-R147) [[2]](diffhunk://#diff-dd8374eb1e491690debbe04fe71354ea54d903ac327aeebfd3dfb09bf0f939f3R165-R181)

### Geographic data retrieval:
* Introduced a `get_country` method in the `SystemChecker` class to determine the user's country based on their IP address, using a bash script and external API calls. This data is included in tracking metadata. (`ersilia/utils/system.py`, [[1]](diffhunk://#diff-ca6d8230f8d390e30e38fb36c3250b583de5c3879854d007d1dc1c58a660b2d3R3-R6) [[2]](diffhunk://#diff-ca6d8230f8d390e30e38fb36c3250b583de5c3879854d007d1dc1c58a660b2d3R82-R143)
* Updated the `RunTracker` class to use the `get_country` method to include geographic data in event summaries. (`ersilia/core/tracking.py`, [[1]](diffhunk://#diff-64965392109ab24f59cfd7848c73d61218fa4dc40aacca63b1e9e3a496fba5e4R346-R366) [[2]](diffhunk://#diff-64965392109ab24f59cfd7848c73d61218fa4dc40aacca63b1e9e3a496fba5e4R413-R422)