### PR TITLE
added exceptions for null publication and source code

### DIFF
--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1017,9 +1017,14 @@ class BaseInformation(ErsiliaBase):
         PublicationBaseInformationError
             If the publication URL is not valid.
         """
-        if not self._is_valid_url(new_publication):
-            raise PublicationBaseInformationError
-        self._publication = new_publication
+        if new_publication is None:
+            self._publication = None
+        elif str(new_publication).lower() == "none" or str(new_publication).lower() == "null":
+            self._publication = None
+        else:
+            if not self._is_valid_url(new_publication):
+                raise PublicationBaseInformationError
+            self._publication = new_publication
 
     @property
     def publication_type(self):
@@ -1115,9 +1120,14 @@ class BaseInformation(ErsiliaBase):
         SourceCodeBaseInformationError
             If the source code URL is not valid.
         """
-        if not self._is_valid_url(new_source_code):
-            raise SourceCodeBaseInformationError
-        self._source_code = new_source_code
+        if new_source_code is None:
+            self._source_code = None
+        elif str(new_source_code).lower() == "none" or str(new_source_code).lower() == "null":
+            self._source_code = None
+        else:
+            if not self._is_valid_url(new_source_code):
+                raise SourceCodeBaseInformationError
+            self._source_code = new_source_code
 
     @property
     def license(self):


### PR DESCRIPTION
This pull request updates the `publication` and `source_code` setter methods in `ersilia/hub/content/base_information.py` to handle `None`, `"none"`, and `"null"` values more gracefully by setting the respective attributes to `None`. This improves the robustness of the code when dealing with invalid or null-like input.

### Handling of null-like values:

* `ersilia/hub/content/base_information.py` (`publication` method): Added checks to set `_publication` to `None` if `new_publication` is `None`, `"none"`, or `"null"`.
* `ersilia/hub/content/base_information.py` (`source_code` method): Added checks to set `_source_code` to `None` if `new_source_code` is `None`, `"none"`, or `"null"`.