### PR TITLE
add exception for contributor, it can be none

### DIFF
--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1671,9 +1671,14 @@ class BaseInformation(ErsiliaBase):
         contributor : str
             Model contributor github handle.
         """
-        if not isinstance(new_contributor, str) or not new_contributor.strip():
-            raise ContributorBaseInformationError
-        self._contributor = new_contributor
+        if new_contributor is None:
+            self._contributor = None
+        elif str(new_contributor).lower() == "none" or str(new_contributor).lower() == "null":
+            self._contributor = None
+        else:
+            if not isinstance(new_contributor, str) or not new_contributor.strip():
+                raise ContributorBaseInformationError
+            self._contributor = new_contributor
 
     @property
     def deployment(self):


### PR DESCRIPTION
This pull request introduces a change in the `contributor` setter method in the `ersilia/hub/content/base_information.py` file to handle cases where the input is `None`, `"none"`, or `"null"` more gracefully.

### Key change:

* [`ersilia/hub/content/base_information.py`](diffhunk://#diff-00769b60d1f1618f896dfd817e6cbe242c2ee57685c72053b4751b15371cdae1R1674-R1678): Updated the `contributor` setter method to set `_contributor` to `None` if the input is `None`, `"none"`, or `"null"`, improving robustness in handling these special cases.