### PR TITLE
update base information with dockerhub

### DIFF
--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -1256,9 +1256,14 @@ class BaseInformation(ErsiliaBase):
         DockerhubBaseInformationError
             If the DockerHub URL is not valid.
         """
-        if not new_dockerhub_url.startswith("https://hub.docker.com/r/ersiliaos/"):
-            raise DockerhubBaseInformationError
-        self._dockerhub = new_dockerhub_url
+        if new_dockerhub_url is None:
+            self._dockerhub = None
+        elif str(new_dockerhub_url).lower() == "none" or str(new_dockerhub_url).lower() == "null":
+            self._dockerhub = None
+        else:
+            if not new_dockerhub_url.startswith("https://hub.docker.com/r/ersiliaos/"):
+                raise DockerhubBaseInformationError
+            self._dockerhub = new_dockerhub_url
 
     @property
     def docker_architecture(self):


### PR DESCRIPTION
This pull request updates the `dockerhub` method in `ersilia/hub/content/base_information.py` to handle cases where the `new_dockerhub_url` is `None`, `"none"`, or `"null"` by setting the `_dockerhub` attribute to `None`.

Key change:

* Updated the `dockerhub` method to check if `new_dockerhub_url` is `None`, `"none"`, or `"null"`, and set the `_dockerhub` attribute to `None` in these cases. This ensures better handling of null-like values for the DockerHub URL.