### PR TITLE
hotfix: using conda run for exectuing any conda related command

### DIFF
--- a/ersilia/publish/test/services/runner.py
+++ b/ersilia/publish/test/services/runner.py
@@ -415,13 +415,16 @@ class RunnerService:
             self.logger.debug("Run script path: {0}".format(run_sh_path))
             self.logger.debug("Output path: {0}".format(output_path))
 
-            bash_script = f"""
-                source {self._conda_prefix(self._is_base())}/etc/profile.d/conda.sh
-                conda activate {self.model_id}
+            bash_script = f"""#!/usr/bin/env bash
+                set -euo pipefail
+
+                echo "Runner arch: $(uname -m)"
+                echo "Using conda prefix: {self._conda_prefix(self._is_base())}"
                 cd {os.path.dirname(run_sh_path)}
-                bash run.sh . {input_file_path} {bash_output_path} > {output_log_path} 2> {error_log_path}
-                conda deactivate
+                conda run -n {self.model_id} bash -lc 'bash ./run.sh . "{input_file_path}" "{bash_output_path}"' \
+                > "{output_log_path}" 2> "{error_log_path}"
                 """
+
 
             with open(temp_script_path, "w") as script_file:
                 script_file.write(bash_script)


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**
- [x] Recently GitHub-hosted **amd64** images (Ubuntu 24.04), the script we are running in test command shel test step in a **non-interactive** shell where `conda` isn’t initialized the same way it is locally (or on the arm64 runner). So `source …/etc/profile.d/conda.sh && conda activate …` silently fails (or activates the wrong prefix), and then `run.sh` runs without the packages we expect → no output file / cryptic errors. The arm64 runner happens to have a setup that makes our current init sequence work.

@GemmaTuron just for the record I updated the bash execution to be like this below to solve the issue:
```python
bash_script = f"""#!/usr/bin/env bash
    set -euo pipefail

    echo "Runner arch: $(uname -m)"
    echo "Using conda prefix: {self._conda_prefix(self._is_base())}"

    conda run -n {self.model_id} bash -c '
    set -euo pipefail
    echo "Inside conda env: $(python -V) - $(which python)"
    cd "{os.path.dirname(run_sh_path)}"
    echo "PWD inside conda run: $(pwd)"
    ls -lah
    bash ./run.sh . "{input_file_path}" "{bash_output_path}"
    '

    if [ ! -f "{bash_output_path}" ]; then
    echo "ERROR: expected output file not found: {bash_output_path}" >&2
    [ -f "{error_log_path}" ] && echo "==== STDERR ====" && cat "{error_log_path}" || true
    [ -f "{output_log_path}" ] && echo "==== STDOUT ====" && cat "{output_log_path}" || true
    exit 1
    fi
    """
```

Related to https://github.com/ersilia-os/eos5cl7/issues/13
Related to https://github.com/ersilia-os/eos39co/issues/4