### PR TITLE
fixed getting run_columns directly from docker container

### DIFF
--- a/API Blog Demo.ipynb
+++ b/API Blog Demo.ipynb
@@ -99,7 +99,7 @@
     "df = pd.read_csv(\"drugbank_input.csv\")\n",
     "input = df.values.tolist()\n",
     "output = fastsolv.run(input[:3], batch_size=1000)\n",
-    "output.to_csv('drugbank_output.csv')"
+    "output.to_csv(\"drugbank_output.csv\")"
    ]
   }
  ],

--- a/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
+++ b/ersilia/hub/fetch/lazy_fetchers/dockerhub.py
@@ -297,12 +297,15 @@ class ModelDockerHubFetcher(ErsiliaBase):
         model_id : str
             ID of the model.
         """
-        dest_path = os.path.join(self._model_path(model_id), "model/framework/columns")
+        self.logger.debug("Copying columns file from model container")
+        dest_path = os.path.join(
+            self._model_path(model_id), "model/framework/columns/run_columns.csv"
+        )
         await self.simple_docker._cp_col_from_container(
             local_path=dest_path,
             img=model_id,
             org=DOCKERHUB_ORG,
-            tag=DOCKERHUB_LATEST_TAG,
+            tag=self.img_tag,
         )
 
     async def modify_information(self, model_id: str):

--- a/ersilia/utils/docker.py
+++ b/ersilia/utils/docker.py
@@ -374,40 +374,48 @@ class SimpleDocker(object):
         run_command(cmd)
 
     async def _cp_col_from_container(self, local_path, org=None, img=None, tag=None):
-        import os
+        """
+        Copy the run_columns.csv file to from the container
 
-        local_path = os.path.abspath(local_path)
-        if not os.path.exists(local_path):
-            os.makedirs(local_path, exist_ok=True)
-        name = self.run(org, img, tag, name=None)
-
-        find_out = os.path.join(make_temp_dir(prefix="ersilia-"), "find.txt")
-        run_command(
-            "docker exec %s sh -lc \"find / -name 'run_columns.csv' -type f -print -quit\" > %s 2>&1"
-            % (name, find_out)
+        Parameters
+        ----------
+        local_path : str
+            The local path to copy files to.
+        org : str, optional
+            The organization name. Default is None.
+        img : str, optional
+            The image name. Default is None.
+        tag : str, optional
+            The image tag. Default is None.
+        """
+        model_id = img
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-i",
+            "--entrypoint",
+            "python",
+            "{0}/{1}:{2}".format(org, img, tag),
+            "-c",
+            "import os, json; base='/root/bundles/{0}'; ".format(model_id)
+            + "dirs=[os.path.join(base,d) for d in os.listdir(base) if os.path.isdir(os.path.join(base,d))]; "
+            "print(json.dumps(dirs))",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        dirs = json.loads(result.stdout)
+        if len(dirs) > 1:
+            raise Exception("More than one version found in the image")
+        img_path = os.path.join(
+            dirs[0], "model", "framework", "columns", "run_columns.csv"
         )
-        with open(find_out, "r") as f:
-            found = f.read().strip()
-
-        if "No such container" in found:
-            img_name = "{0}/{1}:{2}".format(org, img, tag)
-            run_command(
-                "docker run --platform linux/amd64 -d --name={0} {1}".format(
-                    name, img_name
-                )
-            )
-            run_command(
-                "docker exec %s sh -lc \"find / -name 'run_columns.csv' -type f -print -quit\" > %s 2>&1"
-                % (name, find_out)
-            )
-            with open(find_out, "r") as f:
-                found = f.read().strip()
-
-        if not found.startswith("/"):
-            raise FileNotFoundError("run_columns.csv not found in container %s" % name)
-
-        tmp_file = os.path.join(make_temp_dir(prefix="ersilia-"), "tmp.txt")
-        run_command("docker cp %s:%s %s &> %s" % (name, found, local_path, tmp_file))
+        await self.cp_from_image(
+            img_path=img_path,
+            local_path=local_path,
+            org=org,
+            img=img,
+            tag=tag,
+        )
 
     @staticmethod
     def cp_from_container(name, img_path, local_path, org=None, img=None, tag=None):

--- a/notebooks/API_organic_solubility.ipynb
+++ b/notebooks/API_organic_solubility.ipynb
@@ -120,7 +120,7 @@
     }
    ],
    "source": [
-    "print(df[['input', \"solubility_dimethyl_sulfoxide\", \"solubility_heptane\"]])"
+    "print(df[[\"input\", \"solubility_dimethyl_sulfoxide\", \"solubility_heptane\"]])"
    ]
   },
   {


### PR DESCRIPTION
This pull request introduces improvements to the process of copying the `run_columns.csv` file from Docker containers and updates some notebook code for consistency. The most significant change is the refactoring of the Docker file copy logic to be more robust and maintainable, while the notebook updates focus on minor formatting corrections.

**Docker file copy logic improvements:**

* Refactored the `_cp_col_from_container` method in `ersilia/utils/docker.py` to use a more reliable approach for locating and copying `run_columns.csv` from the Docker image, replacing the previous shell-based logic with Python and JSON parsing. It now raises an exception if multiple versions are found and uses a dedicated `cp_from_image` method for copying.
* Updated the `copy_column_file` method in `ersilia/hub/fetch/lazy_fetchers/dockerhub.py` to specify the exact path for `run_columns.csv` and use the correct image tag, with added logging for better traceability.

**Notebook formatting corrections:**

* Fixed inconsistent quotation marks in the DataFrame column selection in `API Blog Demo.ipynb` and `API_organic_solubility.ipynb` for improved readability and code style consistency. [[1]](diffhunk://#diff-18975edbff38968dc8b854b8dd7f7b4a863c49f29e65704d88de4199351c4c0fL102-R102) [[2]](diffhunk://#diff-0316807a7bcdff26915ac572a9ee5b407fd9b461dfdf10870d405c4527641b08L123-R123)