### PR TITLE
hotfix: skipping zairchem models in the catalog command

### DIFF
--- a/ersilia/default.py
+++ b/ersilia/default.py
@@ -10,6 +10,8 @@ EOS = os.path.join(str(Path.home()), "eos")
 EOS_TMP = os.path.join(EOS, "temp")
 if not os.path.exists(EOS):
     os.makedirs(EOS)
+
+ZAIRACHEM_DIR = os.path.join(str(Path.home()), "zairachem")
 EOS_PLAYGROUND = os.path.join(EOS, "playground")
 ROOT = os.path.dirname(os.path.realpath(__file__))
 BENTOML_PATH = os.path.join(str(Path.home()), "bentoml")

--- a/ersilia/hub/content/catalog.py
+++ b/ersilia/hub/content/catalog.py
@@ -6,7 +6,12 @@ import os
 
 from ... import ErsiliaBase
 from ...db.hubdata.interfaces import JsonModelsInterface
-from ...default import AIRTABLE_MODEL_HUB_VIEW_URL, MODEL_SOURCE_FILE, TableConstants
+from ...default import (
+    AIRTABLE_MODEL_HUB_VIEW_URL,
+    MODEL_SOURCE_FILE,
+    ZAIRACHEM_DIR,
+    TableConstants,
+)
 from ...utils.conda import SimpleConda
 from ...utils.docker import SimpleDocker
 from ...utils.exceptions_utils.catalog_exceptions import (
@@ -347,8 +352,19 @@ class ModelCatalog(ErsiliaBase):
         model_ids = self.conda.list_eos_environments()
         return model_ids
 
+    def _read_zairachem_service_file(self):
+        path = os.path.join(ZAIRACHEM_DIR, "service.txt")
+        if not os.path.exists(path):
+            return None
+        with open(path, "r") as f:
+            models = f.readlines()
+        return [m.strip() for m in models]
+
     def _model_ids_in_docker(self):
+        zairachem_models = self._read_zairachem_service_file()
         model_ids = self.docker.list_eos_images()
+        if zairachem_models is not None:
+            model_ids = [m for m in model_ids if m not in zairachem_models]
         return model_ids
 
     @throw_ersilia_exception()


### PR DESCRIPTION
This pull request introduces support for excluding certain models managed by ZairaChem from the list of Docker images in the Ersilia catalog. The changes add a new directory reference and logic to read a service file that lists models to be excluded. The most important changes are grouped below:

**ZairaChem integration:**

* Added a new constant `ZAIRACHEM_DIR` to `ersilia/default.py` to reference the ZairaChem directory in the user's home folder.
* Updated imports in `ersilia/hub/content/catalog.py` to include `ZAIRACHEM_DIR`.

**Model exclusion logic:**

* Implemented `_read_zairachem_service_file` method in `ersilia/hub/content/catalog.py` to read a list of model IDs from `service.txt` in the ZairaChem directory.
* Modified `_model_ids_in_docker` to exclude models listed in the ZairaChem `service.txt` file from the Docker image list.