### PR TITLE
Log a failure when can_delete is False

### DIFF
--- a/ersilia/cli/commands/delete.py
+++ b/ersilia/cli/commands/delete.py
@@ -42,11 +42,13 @@ def delete_cmd():
                 ":collision: Model {0} deleted successfully!".format(model_id),
                 fg="green",
             )
+            return True
         else:
             echo(
                 f":person_tipping_hand: {reason}".format(model_id),
                 fg="yellow",
             )
+            return False
 
     def _delete_all():
         """Function to delete all locally available models"""
@@ -64,17 +66,23 @@ def delete_cmd():
         for model_row in local_models:
             model_id = model_row[idx]
             try:
-                _delete_model_by_id(model_id)
-                deleted_count += 1
+                if _delete_model_by_id(model_id):
+                    deleted_count += 1
             except Exception as e:
                 echo(
                     f":warning: Error deleting model {model_id}: {e}",
                     fg="red",
                 )
-        echo(
-            f":thumbs_up: Completed the deletion of {deleted_count} locally available models!",
-            fg="green",
-        )
+        if deleted_count is len(local_models):
+            echo(
+                f":thumbs_up: Completed the deletion of {deleted_count} locally available models!",
+                fg="green",
+            )
+        else:
+            echo(
+                f":thumbs_down: Failed to delete all models. Deleted {deleted_count} out of {len(local_models)} models.",
+                fg="red"
+            )
 
     # Example usage:
     # 1. Delete a specific model: ersilia delete {MODEL}

--- a/test/cli/test_delete.py
+++ b/test/cli/test_delete.py
@@ -62,6 +62,27 @@ def test_delete_all_models(mock_echo, mock_deleter, mock_catalog):
         result.exit_code == 0
     ), f"Unexpected exit code: {result.exit_code}. Output: {result.output}"
 
+@patch("ersilia.hub.content.catalog.ModelCatalog")
+@patch("ersilia.hub.delete.delete.ModelFullDeleter")
+@patch("ersilia.cli.echo")
+def test_delete_all_models_fails_when_can_be_deleted_is_False(mock_echo, mock_deleter, mock_catalog):
+    runner = CliRunner()
+
+    mock_catalog_instance = MagicMock()
+    mock_catalog_instance.local.return_value.data = [[MODEL], [DUMMY_MODEL]]
+    mock_catalog_instance.local.return_value.columns = ["Identifier"]
+    mock_catalog.return_value = mock_catalog_instance
+
+    mock_deleter_instance = MagicMock()
+    mock_deleter_instance.can_be_deleted.return_value = (False, "")
+    mock_deleter.return_value = mock_deleter_instance
+
+    result = runner.invoke(delete_cmd(), ["delete", "--all"])
+
+    assert (
+        result.exit_code == 0
+    ), f"Unexpected exit code: {result.exit_code}. Output: {result.output}"
+
 
 @patch("ersilia.hub.content.catalog.ModelCatalog")
 @patch("ersilia.cli.echo")


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [ ] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

**Description**

This is my attempt at fixing https://github.com/ersilia-os/ersilia/issues/1761

I updated `_delete_model_by_id` to return True if `can_delete` is true and to return False if `can_delete` is False. That way, we can track if we tried to delete a model or not and then update the messaging accordingly.

So the output looks like this now if docker is stopped/paused:
<img width="478" height="336" alt="image" src="https://github.com/user-attachments/assets/4c9cfe82-c1ce-46b1-9610-edbf078f2100" />

And I also did a manual test to ensure that `ersilia delete --all` still works when docker is running:
<img width="594" height="227" alt="image" src="https://github.com/user-attachments/assets/75a69d30-0c84-44ab-99b4-631bee247141" />

**Changes to be made**

So I updated `_delete_model_by_id` to return a boolean, but I was also thinking that we could raise an exception if can_delete is false. Please let me know what your preference is here 🙇

**Status**

I have the change and I wrote a test, but I need to run the test to make sure it works. I tried running it locally with `pytest`, `pytest -v`, and `pytest test/cli/test_delete.py`, but it was taking a long time to execute....

I also tried [running the workflow in my fork](https://github.com/Lehcar/ersilia/actions/runs/19494367945/job/55792974202), but it returned "No results available."

**To do**
I'm waiting to see if the workflows pass on this PR before I mark this ready for review


Related to https://github.com/ersilia-os/ersilia/issues/1761