### PR TITLE
Test dockerhub conda install

### DIFF
--- a/dockerfiles/dockerize-ersiliapack/base/generate_dockerfiles.py
+++ b/dockerfiles/dockerize-ersiliapack/base/generate_dockerfiles.py
@@ -28,7 +28,15 @@ then
     echo "Model name has not been specified"
     exit 1
 fi
-ersilia_model_serve --bundle_path /root/bundles/$MODEL --port 80
+
+ARGS+=( "--bundle_path" "/root/bundles/$MODEL" "--port" "80" )
+if [ -n "${ROOT_PATH}" ];
+then
+    ARGS+=( "--root_path" "${ROOT_PATH}" )
+fi
+
+ersilia_model_serve "${ARGS[@]}"
+
 echo "Serving model $MODEL..."
 """
 

--- a/ersilia/cli/commands/test.py
+++ b/ersilia/cli/commands/test.py
@@ -100,6 +100,12 @@ def test_cmd():
         default=False,
         help="This flag is used to clean out the temp folder after testing",
     )
+    @click.option(
+        "--permissive",
+        is_flag=True,
+        default=False,
+        help="Downgrade bash consistency check failures to warnings. Only valid with --from_dockerhub.",
+    )
     def test(
         model,
         from_dir,
@@ -113,7 +119,10 @@ def test_cmd():
         inspect,
         report_path,
         clean,
+        permissive,
     ):
+        if permissive and not from_dockerhub:
+            raise click.UsageError("--permissive can only be used together with --from_dockerhub.")
         mt = ModelTester(
             model,
             from_dir,
@@ -127,6 +136,7 @@ def test_cmd():
             inspect,
             report_path,
             clean,
+            permissive,
         )
         echo(f"Model testing started for: {model}")
         mt.run()

--- a/ersilia/publish/test/services/io.py
+++ b/ersilia/publish/test/services/io.py
@@ -329,6 +329,8 @@ class IOService:
                     return False
                 elif "[yellow]✘" in status:
                     return "not present"
+                elif "[yellow]⚠" in status:
+                    return "warning"
                 else:
                     return re.sub(r"\[.*?\]", "", status).strip()
             return status

--- a/ersilia/publish/test/services/io.py
+++ b/ersilia/publish/test/services/io.py
@@ -602,6 +602,12 @@ class PackageInstaller:
         yaml_path = os.path.join(self.dir, INSTALL_YAML_FILE)
         docker_path = os.path.join(self.dir, DOCKERFILE_FILE)
 
+        env_exists = self.conda.exists(self.model_id)
+        env_location = SetupService.get_conda_env_location(self.model_id, self.logger)
+        self.logger.debug(
+            f"[install_packages_from_dir] conda env '{self.model_id}' exists={env_exists} path={env_location}"
+        )
+
         if os.path.exists(yaml_path):
             parser = YAMLInstallParser(self.dir, self.model_id)
         elif os.path.exists(docker_path):

--- a/ersilia/publish/test/services/runner.py
+++ b/ersilia/publish/test/services/runner.py
@@ -98,6 +98,7 @@ class RunnerService:
         inspector: InspectService,
         surface: bool,
         inspect: bool,
+        permissive: bool = False,
     ):
         self.model_id = model_id
         self.logger = logger
@@ -121,6 +122,7 @@ class RunnerService:
         self.example = ExampleGenerator(model_id=self.model_id)
         self.run_using_bash = False
         self.surface = surface
+        self.permissive = permissive
         self.installer = PackageInstaller(self.dir, self.model_id)
 
     def serve_model(self):
@@ -840,6 +842,11 @@ class RunnerService:
                 self._generate_table_from_check(TableType.SHALLOW_CHECK_SUMMARY, res)
             )
             bash_results = self.run_bash()
+            if self.permissive and self.from_dockerhub:
+                bash_results = [
+                    (n, d, str(STATUS_CONFIGS.WARNING)) if s == str(STATUS_CONFIGS.FAILED) else (n, d, s)
+                    for n, d, s in bash_results
+                ]
             validations.append(
                 self._generate_table_from_check(
                     TableType.CONSISTENCY_BASH, bash_results

--- a/ersilia/publish/test/test.py
+++ b/ersilia/publish/test/test.py
@@ -77,6 +77,7 @@ class ModelTester(ErsiliaBase):
         inspect,
         report_path,
         clean,
+        permissive=False,
     ):
         ErsiliaBase.__init__(self, config_json=None, credentials_json=None)
         clean and self.clean_temp()
@@ -94,6 +95,7 @@ class ModelTester(ErsiliaBase):
         self.deep = deep
         self.surface = surface
         self.inspect = inspect
+        self.permissive = permissive
         self.report_path = report_path
         self._check_pedendency()
         self.setup_service = SetupService(
@@ -131,7 +133,8 @@ class ModelTester(ErsiliaBase):
             self.report_path,
             self.inspector,
             self.surface,
-            self.inspect
+            self.inspect,
+            self.permissive,
         )
 
     def _check_pedendency(self):


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

The `test-model-image workflow` was failing intermittently for some models in the `run_bash` consistency check, blocking the Docker image from being retagged as latest. After investigation, these failures were identified as false positives caused by a conda sourcing problem in the CI runner, not by actual issues with the model outputs.

**Changes to be made**

Added a `--permissive` flag to ersilia test, only active in combination with `--from_dockerhub`, that downgrades a `run_bash` failure from false to "warning" in the JSON report instead of blocking the workflow.

**Status**
Implemented and tested locally and with github workflows:

-` --permissive flag` added to CLI, ModelTester, and RunnerService
- `parse_status()` in `io.py` updated to return "warning" for WARNING statuses

**To do**

- Update test-model-image workflow in ersilia-model-workflows to pass --permissive flag

Related to https://github.com/ersilia-os/ersilia/issues/1837