### PR TITLE
feat: divide-and-conquer fallback for failing molecules in batch runs

### DIFF
--- a/ersilia/cli/commands/run.py
+++ b/ersilia/cli/commands/run.py
@@ -100,11 +100,5 @@ def run_cmd():
             fg="green",
             bold=False,
         )
-        if output and output.endswith(".csv"):
-            with open(output, "r") as f:
-                echo(f.read())
-        elif output and output.endswith(".json"):
-            with open(output, "r") as f:
-                echo(json.dumps(json.load(f), indent=2))
 
     return run

--- a/ersilia/core/base.py
+++ b/ersilia/core/base.py
@@ -81,6 +81,8 @@ class ErsiliaBase(object):
 
     def _resolve_pack_method_source(self, model_id):
         bundle_path = self._get_bundle_location(model_id)
+        if bundle_path is None:
+            return None
         if os.path.exists(os.path.join(bundle_path, "installs", "install.sh")):
             return PACK_METHOD_FASTAPI
         self.logger.warning(

--- a/ersilia/serve/autoservice.py
+++ b/ersilia/serve/autoservice.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import shutil
@@ -86,10 +87,13 @@ class AutoService(ErsiliaBase):
         self._url = url
         if service_class is None:
             self.logger.debug("No service class provided, deciding automatically")
-            service_class_file = os.path.join(
-                self._get_bundle_location(model_id), SERVICE_CLASS_FILE
+            bundle_location = self._get_bundle_location(model_id)
+            service_class_file = (
+                os.path.join(bundle_location, SERVICE_CLASS_FILE)
+                if bundle_location is not None
+                else None
             )
-            if os.path.exists(service_class_file):
+            if service_class_file is not None and os.path.exists(service_class_file):
                 self.logger.debug(
                     "Service class file exists in folder {0}".format(service_class_file)
                 )
@@ -136,7 +140,12 @@ class AutoService(ErsiliaBase):
                 self.logger.debug(
                     "No service class file exists in {0}".format(service_class_file)
                 )
-                with open(service_class_file, "w") as f:
+                _ctx = (
+                    open(service_class_file, "w")
+                    if service_class_file is not None
+                    else io.StringIO()
+                )
+                with _ctx as f:
                     if SystemBundleService(
                         model_id, config_json=config_json, preferred_port=preferred_port
                     ).is_available():

--- a/ersilia/serve/services.py
+++ b/ersilia/serve/services.py
@@ -255,7 +255,7 @@ class _LocalService(ErsiliaBase):
                 preferred_port=preferred_port,
             )
         else:
-            raise Exception("Model is not a valid FastAPI model")
+            self.server = None
 
     def _get_apis_from_where_available(self):
         return self.server._get_apis_from_where_available()

--- a/ersilia/serve/standard_api.py
+++ b/ersilia/serve/standard_api.py
@@ -337,6 +337,41 @@ class StandardCSVRunApi(ErsiliaBase):
             f"Fetching batch of size {len(input_batch)}", do_request, input_batch
         )
 
+    def _post_batch_with_fallback(self, url, batch):
+        if not batch:
+            return [], None
+        try:
+            data = self._post_batch(url, batch)
+            if hasattr(data, "json"):
+                data = data.json()
+            if isinstance(data, list):
+                return data, None
+            elif isinstance(data, dict) and "result" in data:
+                batch_meta = data.get("meta") if isinstance(data.get("meta"), dict) else None
+                return data["result"], batch_meta
+            elif data is not None:
+                return [data] * len(batch), None
+            else:
+                return [None] * len(batch), None
+        except Exception as e:
+            self.logger.error(f"Batch of size {len(batch)} failed: {e}")
+            if len(batch) == 1:
+                self.logger.warning(
+                    f"Molecule could not be processed and will have empty output: {batch[0]}"
+                )
+                return [None], None
+            mid = len(batch) // 2
+            left_vals, left_meta = self._post_batch_with_fallback(url, batch[:mid])
+            right_vals, right_meta = self._post_batch_with_fallback(url, batch[mid:])
+            combined_meta = None
+            if left_meta or right_meta:
+                combined_meta = {}
+                if left_meta:
+                    combined_meta.update(left_meta)
+                if right_meta:
+                    combined_meta.update(right_meta)
+            return left_vals + right_vals, combined_meta
+
     def post(self, input, output, batch_size, output_source):
         """
         Post input data to the API in batches and get the output data.
@@ -491,29 +526,16 @@ class StandardCSVRunApi(ErsiliaBase):
                 self.logger.debug(f"Running batch {bidx}")
                 st = time.perf_counter()
 
-                resp = self._post_batch(url, missed_u)
+                api_values, batch_meta = self._post_batch_with_fallback(url, missed_u)
 
                 et = time.perf_counter()
                 echo(f"Batch {bidx} fetched in {et - st:.4f} seconds", fg="green")
                 self.logger.info(f"Batch {bidx} fetched in {et - st:.4f} seconds")
 
-                try:
-                    data = resp.json() if hasattr(resp, "json") else resp
-                except Exception:
-                    data = None
-
-                if isinstance(data, list):
-                    api_values = data
-                elif isinstance(data, dict) and "result" in data:
-                    api_values = data["result"]
-                    if isinstance(data.get("meta"), dict):
-                        if meta is None:
-                            meta = {}
-                        meta.update(data["meta"])
-                elif data is not None:
-                    api_values = [data] * len(missed_u)
-                else:
-                    api_values = []
+                if batch_meta is not None:
+                    if meta is None:
+                        meta = {}
+                    meta.update(batch_meta)
 
             batch_results, batch_repls = self._merge_cache_and_api(
                 payload=payload,
@@ -587,6 +609,8 @@ class StandardCSVRunApi(ErsiliaBase):
                 api_values = [api_values] * len(missed)
             n = min(len(missed), len(api_values))
             for smi, vals in zip(missed[:n], api_values[:n]):
+                if vals is None:
+                    continue
                 if isinstance(vals, dict):
                     api_map[smi] = vals
                 elif isinstance(vals, (list, tuple)):


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

This PR addresses two issues: (1) a crash when running models where one or more molecules in a batch cause the API to error, previously the whole run failed with no output; (2) a `TypeError` crash when serving a model that was fetched from DockerHub and has no local bundle directory.

**Changes to be made**

- Add` _post_batch_with_fallback` to `StandardCSVRunApi`: when a batch POST fails, split it in half and retry each half recursively (divide and conquer). Single molecules that consistently fail are assigned empty output columns in the final CSV rather than aborting the run. Input/output row order is preserved.
- Remove the automatic printing of the full output CSV/JSON content to the terminal after `ersilia run` completes.
- Guard` _get_bundle_location()` returning None in `autoservice.py` and `base.py` so that serving Docker-fetched models  no longer raises a `TypeError`.
- Change `_LocalService.__init__` to set `self.server = None` instead of raising an exception when the pack method is not FastAPI, allowing `is_available()` to be called safely during service class auto-detection.

**Status**
Implemented and tested locally against a Docker-served model with a mixed input containing valid and invalid molecules. The output CSV correctly contains results for all valid molecules and empty columns for failing ones, and the run no longer crashes.

Related to #1839