### PR TITLE
Feat/eosvc GitHub fetch

### DIFF
--- a/ersilia/hub/fetch/actions/get.py
+++ b/ersilia/hub/fetch/actions/get.py
@@ -146,12 +146,16 @@ class ModelRepositoryGetter(BaseAction):
             self, model_id=model_id, config_json=config_json, credentials_json=None
         )
         self.token = self.cfg.HUB.TOKEN
-        self.github_down = GitHubDownloader(self.token)
-        self.s3_down = S3Downloader()
-        self.org = self.cfg.HUB.ORG
         self.force_from_github = force_from_github
         self.force_from_s3 = force_from_s3
         self.repo_path = repo_path
+        self.github_down = GitHubDownloader(
+            overwrite=True,
+            token=self.token,
+            use_eosvc=self.force_from_github,
+        )
+        self.s3_down = S3Downloader()
+        self.org = self.cfg.HUB.ORG
 
     @staticmethod
     def _copy_from_local(src, dst):

--- a/ersilia/hub/fetch/actions/setup.py
+++ b/ersilia/hub/fetch/actions/setup.py
@@ -22,10 +22,13 @@ class SetupChecker(BaseAction):
         Checks all setup requirements.
     """
 
-    def __init__(self, model_id: str, config_json: dict):
+    def __init__(
+        self, model_id: str, config_json: dict, force_from_github: bool = False
+    ):
         BaseAction.__init__(
             self, model_id=model_id, config_json=config_json, credentials_json=None
         )
+        self.force_from_github = force_from_github
 
     def _gh_cli(self):
         req = GithubCliRequirement()
@@ -64,7 +67,12 @@ class SetupChecker(BaseAction):
         Checks all setup requirements.
         """
         self._gh_cli()
-        self._git_lfs()
+        if self.force_from_github:
+            self.logger.debug(
+                "Skipping upfront Git LFS setup for --from_github. It will be installed on demand if eosvc fallback is needed."
+            )
+        else:
+            self._git_lfs()
         self._ping()
         self._conda()
         self._eos_home_path()

--- a/ersilia/hub/fetch/fetch_fastapi.py
+++ b/ersilia/hub/fetch/fetch_fastapi.py
@@ -71,7 +71,11 @@ class ModelFetcherFromFastAPI(ErsiliaBase):
 
     def _setup_check(self):
         echo("Checking setup requirements for the model to be installed and run")
-        sc = SetupChecker(model_id=self.model_id, config_json=self.config_json)
+        sc = SetupChecker(
+            model_id=self.model_id,
+            config_json=self.config_json,
+            force_from_github=self.force_from_github,
+        )
         sc.check()
 
     def _prepare(self):

--- a/ersilia/publish/test/services/setup.py
+++ b/ersilia/publish/test/services/setup.py
@@ -64,7 +64,10 @@ class SetupService:
         ).get("S3")
         self.repo_url = f"{self.BASE_URL}{self.model_id}"
         self.overwrite = self._handle_overwrite()
-        self.github_down = GitHubDownloader(overwrite=self.overwrite)
+        self.github_down = GitHubDownloader(
+            overwrite=self.overwrite,
+            use_eosvc=self.from_github,
+        )
         self.s3_down = S3Downloader()
         self.conda = SimpleConda()
 

--- a/ersilia/setup/requirements/git.py
+++ b/ersilia/setup/requirements/git.py
@@ -1,3 +1,6 @@
+import importlib
+import sys
+
 from ... import throw_ersilia_exception
 from ...utils.exceptions_utils.setup_exceptions import (
     GithubCliSetupError,
@@ -127,3 +130,47 @@ class GitLfsRequirement(object):
         None
         """
         run_command("conda install -c conda-forge git-lfs")
+
+
+class EosvcRequirement(object):
+    """
+    A class to handle checking and installing eosvc in the active Python environment.
+    """
+
+    def __init__(self):
+        self.name = "eosvc"
+        self.install_target = "git+https://github.com/ersilia-os/eosvc.git"
+
+    def is_installed(self) -> bool:
+        """
+        Check whether eosvc is importable in the active environment.
+        """
+        try:
+            importlib.import_module(self.name)
+            return True
+        except ModuleNotFoundError:
+            return False
+
+    def install(self) -> bool:
+        """
+        Install eosvc into the active Python environment.
+        """
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            self.install_target,
+        ]
+        result = run_command(cmd)
+        return result.returncode == 0
+
+    def ensure_installed(self) -> bool:
+        """
+        Ensure eosvc is available in the active Python environment.
+        """
+        if self.is_installed():
+            return True
+        if not self.install():
+            return False
+        return self.is_installed()

--- a/ersilia/utils/download.py
+++ b/ersilia/utils/download.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import uuid
 import zipfile
@@ -194,11 +195,12 @@ class GitHubDownloader(object):
         The GitHub token for authentication. Default is None.
     """
 
-    def __init__(self, overwrite, token=None):
+    def __init__(self, overwrite, token=None, use_eosvc=False):
         self.logger = logger
 
         self.overwrite = overwrite
         self.token = token
+        self.use_eosvc = use_eosvc
 
     @staticmethod
     def _repo_url(org, repo):
@@ -238,6 +240,74 @@ class GitHubDownloader(object):
             f.write(script)
         run_command("bash {0}".format(run_file))
         return self._exists(destination)
+
+    @staticmethod
+    def _access_json_path(destination):
+        return os.path.join(destination, "access.json")
+
+    def _has_access_json(self, destination):
+        return os.path.exists(self._access_json_path(destination))
+
+    def _ensure_git_lfs(self):
+        from ..setup.requirements.git import GitLfsRequirement
+
+        req = GitLfsRequirement()
+        req.is_installed()
+        req.activate()
+
+    def _ensure_eosvc(self):
+        from ..setup.requirements.git import EosvcRequirement
+
+        req = EosvcRequirement()
+        if req.is_installed():
+            return True
+        self.logger.info(
+            "Installing eosvc in the active Python environment for --from_github fetches."
+        )
+        if req.ensure_installed():
+            self.logger.info("eosvc installed successfully.")
+            return True
+        self.logger.warning(
+            "Could not install eosvc automatically. Falling back to Git LFS."
+        )
+        return False
+
+    def _eosvc_download(self, destination, rel_path):
+        return subprocess.run(
+            [sys.executable, "-m", "eosvc.cli", "download", "--path", rel_path],
+            cwd=destination,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=os.environ,
+        )
+
+    def _download_large_files_with_eosvc(self, destination):
+        downloaded_any = False
+        for rel_path in ("checkpoints", "fit"):
+            result = self._eosvc_download(destination, rel_path)
+            if result.returncode == 0:
+                downloaded_any = True
+                continue
+
+            output = "\n".join(
+                x for x in [result.stdout.strip(), result.stderr.strip()] if x
+            )
+            if "Nothing found at s3://" in output:
+                self.logger.debug(
+                    f"eosvc did not find artifacts under '{rel_path}'. Continuing."
+                )
+                continue
+
+            if output:
+                self.logger.warning(
+                    f"eosvc failed while downloading '{rel_path}': {output}"
+                )
+            else:
+                self.logger.warning(f"eosvc failed while downloading '{rel_path}'.")
+            return False
+
+        return downloaded_any
 
     def _list_lfs_files(self, destination):
         clean_lfs_files_list = []
@@ -343,6 +413,7 @@ class GitHubDownloader(object):
         # 4. If there's a discrepancy, tries to fetch only files in question
         # from git lfs.
 
+        self._ensure_git_lfs()
         # Ad 1. List all LFS files.
         lfs_files_list = self._list_lfs_files(destination)
         files_with_incorrect_shasum = []
@@ -360,6 +431,27 @@ class GitHubDownloader(object):
             for files in files_with_incorrect_shasum:
                 self._git_lfs(destination, files["file"])
         self.logger.info("🚀 Model starting...")
+
+    def _download_model_artifacts(self, repo, destination):
+        if self.use_eosvc:
+            if self._has_access_json(destination):
+                self.logger.info(
+                    "Detected access.json in the model repository. Trying eosvc before Git LFS."
+                )
+                if self._ensure_eosvc() and self._download_large_files_with_eosvc(
+                    destination
+                ):
+                    self.logger.info("Model artifacts downloaded with eosvc.")
+                    return
+                self.logger.warning(
+                    "eosvc could not fetch model artifacts. Falling back to Git LFS."
+                )
+            else:
+                self.logger.warning(
+                    "Model repository does not contain access.json. Falling back to Git LFS."
+                )
+
+        self._download_large_files(repo, destination)
 
     def clone(self, org, repo, destination, ungit=False):
         """
@@ -385,7 +477,7 @@ class GitHubDownloader(object):
         if not is_done:
             raise Exception("Download from {0}/{1} did not work".format(org, repo))
 
-        self._download_large_files(repo, destination)
+        self._download_model_artifacts(repo, destination)
 
         if ungit:
             self._ungit(destination)

--- a/ersilia/utils/download.py
+++ b/ersilia/utils/download.py
@@ -13,6 +13,7 @@ import requests
 
 from .. import logger
 from ..default import S3_BUCKET_URL
+from ..utils.echo import echo
 from ..utils.logging import make_temp_dir
 from .terminal import run_command
 
@@ -284,6 +285,7 @@ class GitHubDownloader(object):
 
     def _download_large_files_with_eosvc(self, destination):
         downloaded_any = False
+        had_error = False
         for rel_path in ("checkpoints", "fit"):
             result = self._eosvc_download(destination, rel_path)
             if result.returncode == 0:
@@ -299,15 +301,15 @@ class GitHubDownloader(object):
                 )
                 continue
 
+            had_error = True
             if output:
                 self.logger.warning(
                     f"eosvc failed while downloading '{rel_path}': {output}"
                 )
             else:
                 self.logger.warning(f"eosvc failed while downloading '{rel_path}'.")
-            return False
 
-        return downloaded_any
+        return downloaded_any, had_error
 
     def _list_lfs_files(self, destination):
         clean_lfs_files_list = []
@@ -435,20 +437,31 @@ class GitHubDownloader(object):
     def _download_model_artifacts(self, repo, destination):
         if self.use_eosvc:
             if self._has_access_json(destination):
-                self.logger.info(
-                    "Detected access.json in the model repository. Trying eosvc before Git LFS."
-                )
-                if self._ensure_eosvc() and self._download_large_files_with_eosvc(
-                    destination
-                ):
-                    self.logger.info("Model artifacts downloaded with eosvc.")
-                    return
-                self.logger.warning(
-                    "eosvc could not fetch model artifacts. Falling back to Git LFS."
-                )
+                echo("Detected access.json. Downloading model artifacts via eosvc.")
+                if self._ensure_eosvc():
+                    downloaded, had_error = self._download_large_files_with_eosvc(
+                        destination
+                    )
+                    if downloaded:
+                        echo("Model artifacts downloaded via eosvc.")
+                        return
+                    if had_error:
+                        echo(
+                            "eosvc encountered errors fetching artifacts. Falling back to Git LFS.",
+                            fg="yellow",
+                        )
+                    else:
+                        self.logger.debug(
+                            "eosvc found no artifacts to download. Falling back to Git LFS."
+                        )
+                else:
+                    echo(
+                        "Could not install eosvc automatically. Falling back to Git LFS.",
+                        fg="yellow",
+                    )
             else:
-                self.logger.warning(
-                    "Model repository does not contain access.json. Falling back to Git LFS."
+                self.logger.debug(
+                    "Model repository does not contain access.json. Using Git LFS."
                 )
 
         self._download_large_files(repo, destination)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ersilia"
-version = "0.1.56"
+version = "0.1.57"
 description = "A hub of AI/ML models for open source drug discovery and global health"
 license = "GPLv3"
 authors = ["Ersilia Open Source Initiative <hello@ersilia.io>"]
@@ -55,6 +55,7 @@ nest_asyncio = "<=1.6.0"
 redis = ">=5.1"
 pandas = "^2.0"
 rich-click = "*"
+eosvc = {git= "https://github.com/ersilia-os/eosvc.git"}
 pytest = { version = "^7.4.0", optional = true }
 pytest-asyncio = { version = "<=0.24.0", optional = true }
 pytest-benchmark = { version = "<=4.0.0", optional = true }
@@ -67,6 +68,7 @@ rich = { version = "*", optional = true }
 ruff = { version = "*", optional = true }
 pre-commit = { version = "*", optional = true }
 isaura = { git="https://github.com/ersilia-os/isaura.git", optional = true }
+
 
 [tool.poetry.extras]
 # Instead of using poetry dependency groups, we use extras to make it pip installable


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

Integrates eosvc as an alternative backend for downloading large model artifacts (checkpoints, fit files) from GitHub, replacing Git LFS for models that include an access.json file. When fetching with --from_github, ersilia now checks for access.json in the repository and, if present, uses eosvc to pull artifacts from S3 instead of relying on Git LFS.

**Changes to be made**

- Added `EosvcRequirement` class in `ersilia/setup/requirements/git.py` to check, install, and ensure eosvc is available in the active Python environment at fetch time.

- Extended `GitHubDownloader` in `ersilia/utils/download.py`with a use_eosvc flag and methods to detect `access.json`, auto-install eosvc, and download `checkpoints/fit` directories via eosvc.cli.

- Updated `ModelRepositoryGetter` in `ersilia/hub/fetch/actions/get.py` to pass `use_eosvc=force_from_github `to `GitHubDownloader`.

- Added eosvc as a dependency in `pyproject.toml`

**Status**

Implementation is complete. The eosvc download path is activated when `--from_github` is passed and` access.json` is present in the fetched repo. Falls back to Git LFS if eosvc cannot be installed.


Related to #1836 