### PR TITLE
Add 6 antimicrobial pathogen tags to controlled vocab

### DIFF
--- a/ersilia/hub/content/metadata/tag.txt
+++ b/ersilia/hub/content/metadata/tag.txt
@@ -78,3 +78,9 @@ Biomedical text
 Mycetoma
 Antifungal activity
 Frequent hitter
+C.albicans
+Enterobacter
+Campylobacter
+H.pylori
+S.mansoni
+S.pneumoniae


### PR DESCRIPTION
The [chembl-antimicrobial-hub-incorporation](https://github.com/ersilia-os/chembl-antimicrobial-hub-incorporation) project ships one Hub model per pathogen for 15 antimicrobial-activity QSARs (first one [eos21dr / A. baumannii](https://github.com/ersilia-os/eos21dr) already merged). The next six pathogens need their `short_tag` value in the controlled-vocab `tag.txt`:

- `C.albicans` (*Candida albicans*)
- `Enterobacter` (*Enterobacter spp.*)
- `Campylobacter` (*Campylobacter spp.*)
- `H.pylori` (*Helicobacter pylori*)
- `S.mansoni` (*Schistosoma mansoni*)
- `S.pneumoniae` (*Streptococcus pneumoniae*)

Naming follows the existing convention in the file (`A.baumannii`, `E.coli`, `K.pneumoniae`, `P.aeruginosa`, `S.aureus`, …). Without these the per-pathogen model PRs hit `Field Model Tag has invalid value` at the schema-validation step.

Pure data-file append — no code changes.