### PR TITLE
Add CC-BY-NC-ND-4.0 to accepted license list

### DIFF
--- a/ersilia/hub/content/metadata/license.txt
+++ b/ersilia/hub/content/metadata/license.txt
@@ -11,6 +11,7 @@ BSD-3-Clause
 MPL-2.0
 CC-BY-3.0
 CC-BY-4.0
+CC-BY-NC-ND-4.0
 CC0-1.0
 Proprietary
 None


### PR DESCRIPTION
## Summary

Adds `CC-BY-NC-ND-4.0` (Creative Commons Attribution-NonCommercial-NoDerivatives 4.0) to `ersilia/hub/content/metadata/license.txt`.

This license is used by models such as MolDeBERTa (`eos3wac`), which are publicly available for academic use but restrict commercial use and derivatives. Without this entry, the Airtable sync and metadata validation steps fail for any model with this license.

Context: ersilia-os/ersilia#1881

## Test plan

- [x] Entry added after `CC-BY-4.0` to keep the CC group together
- [x] `[skip ci]` added — this is a one-line metadata change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)