### PR TITLE
fix: replace unsafe eval with ast.literal_eval

### DIFF
--- a/ersilia/io/input.py
+++ b/ersilia/io/input.py
@@ -1,3 +1,4 @@
+import ast
 import csv
 import importlib
 import itertools
@@ -174,9 +175,10 @@ class _GenericAdapter(object):
             return False
 
     def _try_to_eval(self, inp):
+        # use literal_eval instead of eval -- avoids arbitrary code execution
         try:
-            data = eval(inp)
-        except:
+            data = ast.literal_eval(inp)
+        except (ValueError, SyntaxError):
             data = inp
         return data
 

--- a/ersilia/utils/config.py
+++ b/ersilia/utils/config.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 
@@ -128,10 +129,14 @@ class _Field(object):
     def __init__(self, field_kv):
         tmp = dict()
         for k, v in field_kv.items():
-            if type(v) == dict:
+            if isinstance(v, dict):
                 tmp[k] = _Field(v)
             else:
-                tmp[k] = eval(v)
+                # literal_eval is safe; falls back to raw string if it can't parse
+                try:
+                    tmp[k] = ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    tmp[k] = v
         self.__dict__.update(tmp)
 
     def items(self):
@@ -150,10 +155,14 @@ def _eval_obj(json_file):
 
     eval_obj_dict = dict()
     for k, v in obj_dict.items():
-        if type(v) == dict:
+        if isinstance(v, dict):
             eval_obj_dict[k] = _Field(v)
         else:
-            eval_obj_dict[k] = eval(v)
+            # same deal -- don't want arbitrary code running from a config file
+            try:
+                eval_obj_dict[k] = ast.literal_eval(v)
+            except (ValueError, SyntaxError):
+                eval_obj_dict[k] = v
     return eval_obj_dict
 
 


### PR DESCRIPTION


**Description**

This pull request resolves an Arbitrary Code Execution (ACE) vulnerability by replacing unsafe `eval()` calls with `ast.literal_eval()`.

**Changes to be made**

- Add `import ast` to `ersilia/io/input.py` and `ersilia/utils/config.py`.
- Replace `eval(inp)` in `_try_to_eval` inside `ersilia/io/input.py` with `ast.literal_eval(inp)` and narrow exception handling.
- Replace `eval(v)` in both `_Field.__init__` and `_eval_obj` inside `ersilia/utils/config.py` with `ast.literal_eval(v)` (safely falling back to raw string on ValueError/SyntaxError).

**Status**

Completed and verified.

**To do**

N/A

Related to #1877
