### PR TITLE
Upgrade python version because 3.8 is EoL virtualenv no longer supports Python 3.8.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v4.0.0


### PR DESCRIPTION

Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

The latest [release action failed](https://github.com/ersilia-os/ersilia/actions/runs/28493881531/job/84456060058#step:5:23) with the following:
```
Creating virtualenv ersilia-tQhDj4CJ-py3.8 in /home/runner/.cache/pypoetry/virtualenvs

the bundled seeder no longer ships pip/setuptools for Python 3.8; the oldest supported target is Python 3.9 - pass --no-seed for an empty environment, use a seeder that provides Python 3.8 wheels, or install an older virtualenv release
Error: Process completed with exit code 1.
```

**Notes for Reviewer**
* I bumped the python version [like what was previously done two years ago](https://github.com/ersilia-os/ersilia/commit/641fee011f9675d738abf7102cc8f78132bde597), but I'm not sure if this is the right approach. i.e. Will there be any issues going to 3.9/can I bump this to 3.12?
* I'm also unsure on how to test this change without publishing a new package (is there a dry-run option?). I don't have permissions to run the publish action.

Is this pull request related to any open issue? If yes, replace issueID below with the issue ID
N/A