### PR TITLE
Remove intermediate from accepted column directions

### DIFF
--- a/ersilia/hub/content/columns/desired_directions.txt
+++ b/ersilia/hub/content/columns/desired_directions.txt
@@ -1,3 +1,2 @@
 high
-intermediate
 low


### PR DESCRIPTION
## Description

`intermediate` was discarded as a direction category, but the line was never removed from `ersilia/hub/content/columns/desired_directions.txt`. The validator therefore still accepts it, while every other source excludes it:

| Source | Accepted directions |
|---|---|
| [Model template docs](https://ersilia.gitbook.io/ersilia-book/ersilia-model-hub/model-contribution/model-template) | "Only `high` and `low` are accepted" |
| `eos-template` CLAUDE.md | "direction (`high`/`low` or empty)" |
| `desired_directions.txt` (this file) | high, **intermediate**, low |

It has been present since the file was created in #1478 and never edited since.

## Changes to be made

One-line deletion. No migration required: a sweep of all 220 Ready model repositories found **0 of 51,216 column rows** using `intermediate`, so no model changes behaviour. No test references the value.

## Status

Found during a hub-wide `run_columns.csv` metadata sweep. Related to #1899, which covers a separate divergence between the documented and enforced column-name rules.