### PR TITLE
fix: I support metadata.yml in remote updates

### DIFF
--- a/.github/scripts/airtableops.py
+++ b/.github/scripts/airtableops.py
@@ -224,8 +224,8 @@ class MetadataFileUpdater(FileUpdater):
                 return os.path.join(self.tmp_folder, self.model_id, "metadata.json")
             elif os.path.exists(os.path.join(self.tmp_folder, self.model_id, "metadata.yaml")):
                 return os.path.join(self.tmp_folder, self.model_id, "metadata.yaml")
-            elif os.path.exists(os.path.join(self.repo_path, "metadata.yml")):
-                return os.path.join(self.repo_path, "metadata.yml")
+            elif os.path.exists(os.path.join(self.tmp_folder, self.model_id, "metadata.yml")):
+                return os.path.join(self.tmp_folder, self.model_id, "metadata.yml")
             else:
                 print("Metadata file not found")
         else:

--- a/test/fields/test_airtable.py
+++ b/test/fields/test_airtable.py
@@ -15,7 +15,7 @@ DUMMP_API_KEY = "airtable_api_key_456"
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.github/scripts")))
 
-from airtableops import AirtableInterface, AirtableMetadata
+from airtableops import AirtableInterface, AirtableMetadata, MetadataFileUpdater
 
 MOCK_RECORD = {
     "fields": {
@@ -92,3 +92,15 @@ def test_airtable_metadata_find_record(mock_find_record):
     assert data["Computational Performance 3"] == COMPUTATIONAL_PERFORMANCE_3
     assert data["Computational Performance 4"] == COMPUTATIONAL_PERFORMANCE_4
     assert data["Computational Performance 5"] == COMPUTATIONAL_PERFORMANCE_5
+
+
+def test_metadata_file_updater_selects_yml_in_remote_repository(tmp_path):
+    model_path = tmp_path / MODEL_ID
+    model_path.mkdir()
+    metadata_path = model_path / "metadata.yml"
+    metadata_path.write_text("Identifier: eos3b5e\n")
+
+    updater = MetadataFileUpdater(model_id=MODEL_ID)
+    updater.tmp_folder = str(tmp_path)
+
+    assert updater._select_correct_metadata_file() == str(metadata_path)


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] I followed the guidelines in the [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md).
- [x] I wrote a regression test for my core change.
- [x] I successfully ran the focused tests with my change locally.

**Description**

I fix remote metadata updates for model repositories that only contain `metadata.yml`.

**Changes made**

- I resolve the `.yml` candidate against the temporary cloned model directory instead of `repo_path`, which is `None` in remote mode.
- I add a regression test that exercises a remote repository containing only `metadata.yml`.

**Status**

I completed the fix and focused validation.

**Validation**

- `python -m pytest --confcutdir=test/fields test/fields/test_airtable.py::test_metadata_file_updater_selects_yml_in_remote_repository -q` — 1 passed
- `python -m pytest --confcutdir=test/fields test/fields/test_airtable.py -q` — 4 passed
- `ruff check --select E9,F63,F7,F82 .github/scripts/airtableops.py test/fields/test_airtable.py` — passed
- `git diff --check upstream/master...HEAD` — passed

I left the repository-wide conda, Docker, and model integration matrix to CI.

Fixes #1902
