### PR TITLE
Fix TypeError in metadata file selection for metadata.yml-only repos in remote mode

### DIFF
--- a/.github/scripts/airtableops.py
+++ b/.github/scripts/airtableops.py
@@ -220,23 +220,14 @@ class MetadataFileUpdater(FileUpdater):
 
     def _select_correct_metadata_file(self):
         if self.repo_path is None:
-            if os.path.exists(os.path.join(self.tmp_folder, self.model_id, "metadata.json")):
-                return os.path.join(self.tmp_folder, self.model_id, "metadata.json")
-            elif os.path.exists(os.path.join(self.tmp_folder, self.model_id, "metadata.yaml")):
-                return os.path.join(self.tmp_folder, self.model_id, "metadata.yaml")
-            elif os.path.exists(os.path.join(self.repo_path, "metadata.yml")):
-                return os.path.join(self.repo_path, "metadata.yml")
-            else:
-                print("Metadata file not found")
+            base_dir = os.path.join(self.tmp_folder, self.model_id)
         else:
-            if os.path.exists(os.path.join(self.repo_path, "metadata.json")):
-                return os.path.join(self.repo_path, "metadata.json")
-            elif os.path.exists(os.path.join(self.repo_path, "metadata.yaml")):
-                return os.path.join(self.repo_path, "metadata.yaml")
-            elif os.path.exists(os.path.join(self.repo_path, "metadata.yml")):
-                return os.path.join(self.repo_path, "metadata.yml")
-            else:
-                print("Metadata file not found")
+            base_dir = self.repo_path
+        for filename in ("metadata.json", "metadata.yaml", "metadata.yml"):
+            path = os.path.join(base_dir, filename)
+            if os.path.exists(path):
+                return path
+        print("Metadata file not found")
     
     def update_remote_from_airtable(self):
         self._git_clone()


### PR DESCRIPTION
Fixes #1902

`MetadataFileUpdater._select_correct_metadata_file` resolved its third candidate against `self.repo_path` inside the `repo_path is None` branch, raising `TypeError` in remote mode for any model repo whose only metadata file is `metadata.yml`; the second candidate also checked `metadata.yaml` where model repos use `metadata.yml`. This collapses the two duplicated branches into one probe over `("metadata.json", "metadata.yaml", "metadata.yml")` against the correct base directory, preserving probe order and the existing not-found behavior.

Also fixed as a side effect: in remote mode with no metadata file at all, the function previously raised the same `TypeError` instead of reaching the "Metadata file not found" message.

Verified with a four-case matrix (remote/.yml-only, remote/json-preference, local/.yml, remote/none): the first and last cases fail on master with `TypeError` and pass with this change; the middle two pass before and after. Pre-existing black violations elsewhere in the file were left untouched to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)