### PR TITLE
Add run columns name check and improve metadata validation errors

### DIFF
--- a/ersilia/hub/content/base_information.py
+++ b/ersilia/hub/content/base_information.py
@@ -49,6 +49,7 @@ from ...utils.exceptions_utils.base_information_exceptions import (
     TitleBaseInformationError,
 )
 from ...utils.identifiers.model import ModelIdentifier
+from .base_information_validator import BaseInformationValidator
 
 
 class BaseInformation(ErsiliaBase):
@@ -307,11 +308,7 @@ class BaseInformation(ErsiliaBase):
         SlugBaseInformationError
             If the slug is not valid.
         """
-        if new_slug.lower() != new_slug:
-            raise SlugBaseInformationError
-        if len(new_slug) > 60:
-            raise SlugBaseInformationError
-        if len(new_slug) < 5:
+        if not BaseInformationValidator.validate_slug(new_slug):
             raise SlugBaseInformationError
         self._slug = new_slug
 
@@ -373,9 +370,7 @@ class BaseInformation(ErsiliaBase):
         TitleBaseInformationError
             If the title is not valid.
         """
-        if len(new_title) > 300:
-            raise TitleBaseInformationError
-        if len(new_title) < 10:
+        if not BaseInformationValidator.validate_title(new_title):
             raise TitleBaseInformationError
         self._title = new_title
 

--- a/ersilia/hub/content/base_information_validator.py
+++ b/ersilia/hub/content/base_information_validator.py
@@ -23,6 +23,10 @@ _SEMVER_REGEX = re.compile(
     re.VERBOSE,
 )
 
+_SLUG_REGEX = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+){0,3}$")
+
+_MAX_SLUG_LENGTH = 60
+
 
 class BaseInformationValidator:
     @staticmethod
@@ -88,7 +92,11 @@ class BaseInformationValidator:
 
     @classmethod
     def validate_slug(cls, s) -> bool:
-        return s.lower() == s and 5 <= len(s) <= 60
+        return (
+            isinstance(s, str)
+            and len(s) <= _MAX_SLUG_LENGTH
+            and _SLUG_REGEX.match(s) is not None
+        )
 
     @classmethod
     def validate_status(cls, s) -> bool:
@@ -96,7 +104,7 @@ class BaseInformationValidator:
 
     @classmethod
     def validate_title(cls, t) -> bool:
-        return 10 <= len(t) <= 300
+        return isinstance(t, str) and 10 <= len(t) <= 300
 
     @classmethod
     def validate_description(cls, d) -> bool:
@@ -155,7 +163,7 @@ class BaseInformationValidator:
         return ot is None or all(
             v in cls._read_default_fields("Output Type") for v in cls.to_list(ot)
         )
-
+   
     @classmethod
     def validate_output_shape(cls, osz) -> bool:
         return osz is None or osz in cls._read_default_fields("Output Shape")

--- a/ersilia/hub/content/columns_information.py
+++ b/ersilia/hub/content/columns_information.py
@@ -84,8 +84,8 @@ class ColumnsInformation(ErsiliaBase):
 
     def _validate_columns_data(self, data):
         for d in data["name"]:
-            if d[0].lower() != d[0]:
-                raise ValueError("Column names must be lowercase")
+            if d.islower() is False:
+                raise ValueError("Column names allmust be lowercase")
             if not d.replace("_", "").isalnum():
                 raise ValueError(
                     "Column names must be alphanumeric or contain underscores"

--- a/ersilia/publish/test/services/checks.py
+++ b/ersilia/publish/test/services/checks.py
@@ -22,7 +22,7 @@ from ....utils.exceptions_utils import test_exceptions as texc
 from ....utils.hdf5 import Hdf5DataLoader
 from ....store.utils import echo_exceptions, ClickInterface
 from ....hub.content.base_information_validator import BaseInformationValidator
-
+from ....hub.content.columns_information import ColumnsInformation
 
 class CheckService:
     """
@@ -107,12 +107,20 @@ class CheckService:
             raise texc.WrongCardIdentifierError(self.model_id)
 
     def _check_model_slug(self, data):
-        self.logger.debug("Checking model slug...")
-        if not data["Slug"]:
-            raise texc.EmptyField("slug")
+        key = "Slug"
+        self.logger.debug(f"Checking {key} field..")
 
-        if not BaseInformationValidator().validate_slug(data["Slug"]):
-            raise texc.EmptyField("slug")
+        if key not in data:
+            raise texc.EmptyKey(key)
+
+        if not data[key]:
+            raise texc.EmptyField(key)
+
+        if not BaseInformationValidator().validate_slug(data[key]):
+            raise texc.InvalidEntry(
+                key,
+                "A slug must be 1-4 lowercase words separated by hyphens, at most 60 characters.",
+            )
 
     def _check_model_description(self, data):
         self.logger.debug("Checking model description...")
@@ -151,13 +159,17 @@ class CheckService:
             raise texc.EmptyField(key)
 
     def _check_model_source_title(self, data):
-        self.logger.debug("Checking model title...")
+        key = "Title"
+        self.logger.debug(f"Checking {key} field..")
 
-        if not BaseInformationValidator().validate_title(data["Title"]):
-            raise texc.EmptyField("Title")
+        if key not in data:
+            raise texc.EmptyKey(key)
 
-        if not data["Title"]:
-            raise texc.EmptyField("Title")
+        if not data[key]:
+            raise texc.EmptyField(key)
+
+        if not BaseInformationValidator().validate_title(data[key]):
+            raise texc.InvalidEntry(key)
 
     def _check_model_status(self, data):
         self.logger.debug("Checking model status...")
@@ -347,7 +359,7 @@ class CheckService:
 
         if not data[key]:
             raise texc.EmptyField(key)
-
+        
     def _check_model_output_consistency(self, data):
         key = "Output Consistency"
 
@@ -1130,6 +1142,30 @@ class CheckService:
             )
         ]
 
+    def check_model_columns_name(self):
+        column_names= self.ios.get_model_run_columns()
+        if not column_names:
+            return (
+                f"Column names validation check",
+                "No column names found in the model run file",
+                str(STATUS_CONFIGS.FAILED),
+            )
+        
+        for d in column_names:
+            if d.islower() is False or not d.replace("_", "").isalnum():
+                return (
+                    f"Column names validation check",
+                    "Column names are not valid: must be lowercase and alphanumeric with underscores",
+                    str(STATUS_CONFIGS.FAILED),
+                )
+           
+        return (
+            f"Column names validation check",
+            "Column names are valid",
+            str(STATUS_CONFIGS.PASSED),
+        )
+
+        
     def compare_csv_columns(self, column_csv, csv_file):
         try:
             with ExitStack() as stack:

--- a/ersilia/publish/test/services/io.py
+++ b/ersilia/publish/test/services/io.py
@@ -199,7 +199,17 @@ class IOService:
         except texc.EmptyField as ef:
             self.logger.error(f"EmptyField exception caught for key '{ef}'")
             details = (
-                f"Field {check_name} has invalid value"
+                f"Field {check_name} is empty"
+                if data
+                else f"File {check_name} does not exist"
+            )
+            self.check_results.append((check_name, details, str(STATUS_CONFIGS.FAILED)))
+            return False
+
+        except texc.InvalidEntry as ie:
+            self.logger.error(f"InvalidEntry exception caught for key '{ie}'")
+            details = (
+                f"Field {check_name} value does not meet the expected format"
                 if data
                 else f"File {check_name} does not exist"
             )
@@ -497,7 +507,20 @@ class IOService:
         odc = len(IOService.read_csv_values(path))
         return odm, odc
 
+    def get_model_run_columns(self):
+        """
+        Get the model run columns from run column file
 
+        Returns
+        -------
+        list
+          A run columns name from the run column file
+        """
+        path = os.path.join(self.dir, PREDEFINED_COLUMN_FILE)
+        data = IOService.read_csv_values(path)
+        column_names = [row[0] for row in data if row]
+        return column_names
+    
     @throw_ersilia_exception()
     def get_directories_sizes(self) -> str:
         """

--- a/ersilia/publish/test/services/runner.py
+++ b/ersilia/publish/test/services/runner.py
@@ -733,10 +733,12 @@ class RunnerService:
             )
         )
         dim_check = self.checkup_service.check_dim()
-        results.append(
-            self._generate_table_from_check(TableType.MODEL_FILE_CHECKS, [dim_check])
-        )
 
+        column_name_check = self.checkup_service.check_model_columns_name()
+        results.append(
+            self._generate_table_from_check(TableType.MODEL_FILE_CHECKS, [dim_check, column_name_check])
+        )
+       
         results.append(self._log_directory_sizes())
 
         docker_check = self._docker_yml_column_name_check()

--- a/ersilia/utils/exceptions_utils/base_information_exceptions.py
+++ b/ersilia/utils/exceptions_utils/base_information_exceptions.py
@@ -38,7 +38,7 @@ class IdentifierBaseInformationError(ErsiliaError):
 class SlugBaseInformationError(ErsiliaError):
     def __init__(self):
         self.message = "Wrong Ersilia slug"
-        self.hints = "Slug must be a 5-60 chars lowercase single-word unique identifier. Use '-' for linking words if necessary"
+        self.hints = "Slug must be a lowercase unique identifier of at most 60 characters, made of 1 to 4 words. Use '-' for linking words if necessary"
         ErsiliaError.__init__(self, self.message, self.hints)
 
 

--- a/ersilia/utils/exceptions_utils/test_exceptions.py
+++ b/ersilia/utils/exceptions_utils/test_exceptions.py
@@ -63,8 +63,7 @@ class InvalidEntry(ErsiliaError):
             )
         )
         if reason:
-            self.message += "  {0}".format(reason)
-            
+            self.message += "  {0}".format(reason)   
         self.hints = (
             "Check the model information, usually available in a metadata.json file."
         )

--- a/ersilia/utils/exceptions_utils/test_exceptions.py
+++ b/ersilia/utils/exceptions_utils/test_exceptions.py
@@ -63,7 +63,7 @@ class InvalidEntry(ErsiliaError):
             )
         )
         if reason:
-            self.message += "  {0}".format(reason)   
+            self.message += "  {0}".format(reason)
         self.hints = (
             "Check the model information, usually available in a metadata.json file."
         )

--- a/ersilia/utils/exceptions_utils/test_exceptions.py
+++ b/ersilia/utils/exceptions_utils/test_exceptions.py
@@ -56,12 +56,15 @@ class EmptyKey(ErsiliaError):
 
 
 class InvalidEntry(ErsiliaError):
-    def __init__(self, invalid_field):
+    def __init__(self, invalid_field, reason=None):
         self.message = (
             "The {0} field of this model is not recognized as a valid format.".format(
                 invalid_field
             )
         )
+        if reason:
+            self.message += "  {0}".format(reason)
+            
         self.hints = (
             "Check the model information, usually available in a metadata.json file."
         )


### PR DESCRIPTION
Thank you for taking your time to contribute to Ersilia, just a few checks before we proceed
- [x] Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

**Description**

Adds a validation check for the column names declared in `run_columns.csv`, and makes metadata validation failures report why they failed instead of always saying the field is empty. Also tightens slug validation and removes duplicated validation rules.

**Changes to be made**

- Add check_model_columns_name to the Model File Checks table
- Tighten slug validation (lowercase, hyphens, 1-4 words, max 60 chars)
- Delegate slug and title setters to BaseInformationValidator
- Report invalid values as InvalidEntry instead of EmptyField

**Status**

done


Related to #1899 